### PR TITLE
feat: 유저 프로필 조회 API 연동

### DIFF
--- a/build-logic/src/main/kotlin/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidFeatureConventionPlugin.kt
@@ -24,6 +24,8 @@ internal class AndroidFeatureConventionPlugin : Plugin<Project> {
                 implementation(project(path = ":core:model"))
                 implementation(project(path = ":core:ui"))
 
+                implementation(libs.compose.effects)
+
                 implementation(libs.bundles.circuit)
 
                 api(libs.circuit.codegen.annotation)

--- a/core/data/api/src/main/kotlin/com/ninecraft/booket/core/data/api/repository/UserRepository.kt
+++ b/core/data/api/src/main/kotlin/com/ninecraft/booket/core/data/api/repository/UserRepository.kt
@@ -1,0 +1,7 @@
+package com.ninecraft.booket.core.data.api.repository
+
+import com.ninecraft.booket.core.model.UserProfileModel
+
+interface UserRepository {
+    suspend fun getUserProfile(): Result<UserProfileModel>
+}

--- a/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/di/RepositoryModule.kt
+++ b/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/di/RepositoryModule.kt
@@ -1,7 +1,9 @@
 package com.ninecraft.booket.core.data.impl.di
 
 import com.ninecraft.booket.core.data.api.repository.AuthRepository
+import com.ninecraft.booket.core.data.api.repository.UserRepository
 import com.ninecraft.booket.core.data.impl.repository.DefaultAuthRepository
+import com.ninecraft.booket.core.data.impl.repository.DefaultUserRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -15,4 +17,8 @@ internal abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindAuthRepository(defaultAuthRepository: DefaultAuthRepository): AuthRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindUserRepository(defaultUserRepository: DefaultUserRepository): UserRepository
 }

--- a/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/mapper/ResponseToModel.kt
+++ b/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/mapper/ResponseToModel.kt
@@ -1,11 +1,22 @@
 package com.ninecraft.booket.core.data.impl.mapper
 
 import com.ninecraft.booket.core.model.LoginModel
+import com.ninecraft.booket.core.model.UserProfileModel
 import com.ninecraft.booket.core.network.response.LoginResponse
+import com.ninecraft.booket.core.network.response.UserProfileResponse
 
 internal fun LoginResponse.toModel(): LoginModel {
     return LoginModel(
         accessToken = accessToken,
         refreshToken = refreshToken,
+    )
+}
+
+internal fun UserProfileResponse.toModel(): UserProfileModel {
+    return UserProfileModel(
+        id = id,
+        email = email,
+        nickname = nickname,
+        provider = provider,
     )
 }

--- a/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/repository/DefaultUserRepository.kt
+++ b/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/repository/DefaultUserRepository.kt
@@ -1,0 +1,15 @@
+package com.ninecraft.booket.core.data.impl.repository
+
+import com.ninecraft.booket.core.common.utils.runSuspendCatching
+import com.ninecraft.booket.core.data.api.repository.UserRepository
+import com.ninecraft.booket.core.data.impl.mapper.toModel
+import com.ninecraft.booket.core.network.service.AuthService
+import javax.inject.Inject
+
+internal class DefaultUserRepository @Inject constructor(
+    private val authService: AuthService,
+) : UserRepository {
+    override suspend fun getUserProfile() = runSuspendCatching {
+        authService.getUserProfile().toModel()
+    }
+}

--- a/core/model/src/main/kotlin/com/ninecraft/booket/core/model/UserProfileModel.kt
+++ b/core/model/src/main/kotlin/com/ninecraft/booket/core/model/UserProfileModel.kt
@@ -1,0 +1,8 @@
+package com.ninecraft.booket.core.model
+
+data class UserProfileModel(
+    val id: String,
+    val email: String,
+    val nickname: String,
+    val provider: String,
+)

--- a/core/network/src/main/kotlin/com/ninecraft/booket/core/network/response/UserProfileResponse.kt
+++ b/core/network/src/main/kotlin/com/ninecraft/booket/core/network/response/UserProfileResponse.kt
@@ -1,0 +1,16 @@
+package com.ninecraft.booket.core.network.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserProfileResponse(
+    @SerialName("id")
+    val id: String,
+    @SerialName("email")
+    val email: String,
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("provider")
+    val provider: String,
+)

--- a/core/network/src/main/kotlin/com/ninecraft/booket/core/network/service/AuthService.kt
+++ b/core/network/src/main/kotlin/com/ninecraft/booket/core/network/service/AuthService.kt
@@ -1,8 +1,13 @@
 package com.ninecraft.booket.core.network.service
 
+import com.ninecraft.booket.core.network.response.UserProfileResponse
+import retrofit2.http.GET
 import retrofit2.http.POST
 
 interface AuthService {
     @POST("api/v1/auth/signout")
     suspend fun logout()
+
+    @GET("api/v1/auth/me")
+    suspend fun getUserProfile(): UserProfileResponse
 }

--- a/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryPresenter.kt
+++ b/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryPresenter.kt
@@ -1,12 +1,14 @@
 package com.ninecraft.booket.feature.library
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import com.ninecraft.booket.core.common.utils.handleException
 import com.ninecraft.booket.core.data.api.repository.AuthRepository
+import com.ninecraft.booket.core.data.api.repository.UserRepository
 import com.ninecraft.booket.feature.login.LoginScreen
 import com.orhanobut.logger.Logger
 import com.slack.circuit.codegen.annotations.CircuitInject
@@ -21,7 +23,8 @@ import kotlinx.coroutines.launch
 
 class LibraryPresenter @AssistedInject constructor(
     @Assisted private val navigator: Navigator,
-    private val repository: AuthRepository,
+    private val authRepository: AuthRepository,
+    private val userRepository: UserRepository,
 ) : Presenter<LibraryScreen.State> {
 
     @Composable
@@ -29,6 +32,38 @@ class LibraryPresenter @AssistedInject constructor(
         val scope = rememberCoroutineScope()
         var isLoading by rememberRetained { mutableStateOf(false) }
         var sideEffect by rememberRetained { mutableStateOf<LibraryScreen.SideEffect?>(null) }
+        var nickname by rememberRetained { mutableStateOf("") }
+        var email by rememberRetained { mutableStateOf("") }
+
+        LaunchedEffect(Unit) {
+            scope.launch {
+                try {
+                    isLoading = true
+                    userRepository.getUserProfile()
+                        .onSuccess { user ->
+                            nickname = user.nickname
+                            email = user.email
+                        }
+                        .onFailure { exception ->
+                            val handleErrorMessage = { message: String ->
+                                Logger.e(message)
+                                sideEffect = LibraryScreen.SideEffect.ShowToast(message)
+                            }
+
+                            handleException(
+                                exception = exception,
+                                onServerError = handleErrorMessage,
+                                onNetworkError = handleErrorMessage,
+                                onLoginRequired = {
+                                    navigator.resetRoot(LoginScreen)
+                                },
+                            )
+                        }
+                } finally {
+                    isLoading = false
+                }
+            }
+        }
 
         fun handleEvent(event: LibraryScreen.Event) {
             when (event) {
@@ -40,9 +75,9 @@ class LibraryPresenter @AssistedInject constructor(
                     scope.launch {
                         try {
                             isLoading = true
-                            repository.logout()
+                            authRepository.logout()
                                 .onSuccess {
-                                    repository.clearTokens()
+                                    authRepository.clearTokens()
                                     navigator.resetRoot(LoginScreen)
                                 }
                                 .onFailure { exception ->
@@ -70,6 +105,8 @@ class LibraryPresenter @AssistedInject constructor(
 
         return LibraryScreen.State(
             isLoading = isLoading,
+            nickname = nickname,
+            email = email,
             sideEffect = sideEffect,
             eventSink = ::handleEvent,
         )

--- a/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryPresenter.kt
+++ b/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryPresenter.kt
@@ -1,7 +1,6 @@
 package com.ninecraft.booket.feature.library
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
@@ -11,6 +10,7 @@ import com.ninecraft.booket.core.data.api.repository.AuthRepository
 import com.ninecraft.booket.core.data.api.repository.UserRepository
 import com.ninecraft.booket.feature.login.LoginScreen
 import com.orhanobut.logger.Logger
+import com.skydoves.compose.effects.RememberedEffect
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.Navigator
@@ -35,7 +35,7 @@ class LibraryPresenter @AssistedInject constructor(
         var nickname by rememberRetained { mutableStateOf("") }
         var email by rememberRetained { mutableStateOf("") }
 
-        LaunchedEffect(Unit) {
+        fun getUserProfile() {
             scope.launch {
                 try {
                     isLoading = true
@@ -63,6 +63,10 @@ class LibraryPresenter @AssistedInject constructor(
                     isLoading = false
                 }
             }
+        }
+
+        RememberedEffect(Unit) {
+            getUserProfile()
         }
 
         fun handleEvent(event: LibraryScreen.Event) {

--- a/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryScreen.kt
@@ -3,6 +3,7 @@ package com.ninecraft.booket.feature.library
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -31,6 +32,8 @@ import kotlinx.parcelize.Parcelize
 data object LibraryScreen : Screen {
     data class State(
         val isLoading: Boolean = false,
+        val nickname: String = "",
+        val email: String = "",
         val sideEffect: SideEffect? = null,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
@@ -51,6 +54,11 @@ internal fun Library(
     state: LibraryScreen.State,
     modifier: Modifier = Modifier,
 ) {
+    HandleLibrarySideEffects(
+        state = state,
+        eventSink = state.eventSink,
+    )
+
     Column(
         modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -68,21 +76,23 @@ internal fun LibraryContent(
     state: LibraryScreen.State,
     modifier: Modifier = Modifier,
 ) {
-    HandleLibrarySideEffects(
-        state = state,
-        eventSink = state.eventSink,
-    )
-
     Column(
         modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
         Box(modifier = modifier.fillMaxSize()) {
-            Text(
-                text = "내 서재",
-                modifier = Modifier.align(Alignment.Center),
-            )
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(text = "내 서재")
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(text = state.nickname)
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(text = state.email)
+            }
             BooketButton(
                 onClick = {
                     state.eventSink(LibraryScreen.Event.OnLogoutButtonClick)
@@ -118,6 +128,8 @@ private fun LibraryPreview() {
     BooketTheme {
         Library(
             state = LibraryScreen.State(
+                nickname = "홍길동",
+                email = "test@test.com",
                 eventSink = {},
             ),
         )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ androidx-datastore = "1.1.7"
 androidx-compose-bom = "2025.06.00"
 androidx-compose-material3 = "1.4.0-alpha15"
 compose-stable-marker = "1.0.6"
-
+compose-effects = "0.1.1"
 coil-compose = "2.7.0"
 
 ## Kotlin Symbol Processing
@@ -87,6 +87,7 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "androidx-compose-material3" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended"}
 compose-stable-marker = { group = "com.github.skydoves", name = "compose-stable-marker", version.ref = "compose-stable-marker" }
+compose-effects = { group = "com.github.skydoves", name = "compose-effects", version.ref = "compose-effects" }
 
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close https://github.com/YAPP-Github/Reed-Android/issues/28

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 유저 프로필 조회 API 연동
- 유저 정보(닉네임, 이메일)를 내서재 화면내에 load

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기
|:--:|:--:|
| 기능 설명 |<img src="https://github.com/user-attachments/assets/31823228-6813-416c-8eb1-fafb53c27b2f" width="300" />|

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- Loading Initial Data 관련해서 더 좋은 방법이 있을지 의견 주시면 감사하겠습니다. 저도 더 고민해보려구요! 
- 더 고민해본 결과, API를 통해 받아온 데이터를 state로 관리하는 경우(이후 변경될 가능성이 있는 경우), 기존 compose에서 제공하는 SideEffect API 인 `produceState`와 유사한 Circuit의 `produceRetainedState`를 사용하여 non-Compose 상태를 Compose 상태로 변환하여 사용하는 것이 괜찮을 것 같다고 생각했니다.(관련해서 예시 코드 첨부하도록 하겠습니다.)
- `rememberEffect`는 skydoves님의 [compose-effects](https://github.com/skydoves/compose-effects)에서 지원하는 API로 `LaunchedEffect`와 매우 흡사하나, 내부에 코루틴 스코프가 존재하지않아, 매번 코루틴 스코프를 생성하는 비용을 아낄수있습니다. LaunchedEffect를 사용할때 내부에서 suspend 함수를 호출하지 않는 경우, flow를 collect하지 않는 경우등에 사용하면 좋을 것 같아 채택을 해보았습니다 
- 이후 내 서재 화면 시안 나오면, 현재 작업내역은 지우도록 하겠습니다 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자 프로필(닉네임, 이메일) 조회 및 표시 기능이 추가되었습니다. 라이브러리 화면에서 사용자 정보를 확인할 수 있습니다.

* **UI 개선**
  * 라이브러리 화면에 사용자 닉네임과 이메일이 표시됩니다.

* **버그 수정**
  * 프로필 조회 실패 시 오류 메시지 표시 및 로그인 필요 시 로그인 화면으로 이동하도록 개선되었습니다.

* **기타**
  * 새로운 라이브러리 및 내부 구조 개선이 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->