### PR TITLE
feat: 오픈소스 라이선스 화면 UI 구현

### DIFF
--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/extensions/Modifier.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/extensions/Modifier.kt
@@ -1,9 +1,9 @@
 package com.ninecraft.booket.core.common.extensions
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -44,7 +44,7 @@ fun Modifier.clickableSingle(
         onClickLabel = onClickLabel,
         onClick = { multipleEventsCutter.processEvent { onClick() } },
         role = role,
-        indication = LocalIndication.current,
+        indication = ripple(),
         interactionSource = remember { MutableInteractionSource() },
     )
 }

--- a/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/appbar/ReedTopAppBar.kt
+++ b/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/appbar/ReedTopAppBar.kt
@@ -62,7 +62,7 @@ fun ReedTopAppBar(
             text = title,
             modifier = Modifier.weight(1f),
             textAlign = TextAlign.Center,
-            style = ReedTheme.typography.heading2SemiBold,
+            style = ReedTheme.typography.headline2SemiBold,
         )
 
         if (endIconRes != null) {

--- a/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/appbar/ReedTopAppBar.kt
+++ b/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/appbar/ReedTopAppBar.kt
@@ -87,14 +87,14 @@ fun ReedTopAppBar(
 fun ReedBackTopAppBar(
     modifier: Modifier = Modifier,
     title: String = "",
-    onNavigateBack: () -> Unit = {},
+    onBackClick: () -> Unit = {},
 ) {
     ReedTopAppBar(
         modifier = modifier,
         title = title,
         startIconRes = R.drawable.ic_chevron_left,
         startIconDescription = "Back",
-        startIconOnClick = onNavigateBack,
+        startIconOnClick = onBackClick,
     )
 }
 

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/TermsAgreementScreen.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/TermsAgreementScreen.kt
@@ -50,7 +50,7 @@ internal fun TermsAgreement(
             .background(White),
     ) {
         ReedBackTopAppBar(
-            onNavigateBack = {
+            onBackClick = {
                 state.eventSink(TermsAgreementUiEvent.OnBackClick)
             },
         )

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     alias(libs.plugins.booket.android.feature)
-    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.booket.kotlin.library.serialization)
     alias(libs.plugins.kotlin.parcelize)
 }
 
@@ -17,6 +17,5 @@ ksp {
 dependencies {
     implementations(
         libs.logger,
-        libs.kotlinx.serialization.json,
     )
 }

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -17,5 +17,6 @@ ksp {
 dependencies {
     implementations(
         libs.logger,
+        libs.kotlinx.serialization.json,
     )
 }

--- a/feature/settings/src/main/assets/oss_licenses.json
+++ b/feature/settings/src/main/assets/oss_licenses.json
@@ -37,7 +37,7 @@
     {
         "name": "OkHttp Logging Interceptor",
         "license": "Apache License 2.0",
-        "url": "https://square.github.io/okhttp/"
+        "url": "https://github.com/square/okhttp/tree/master/okhttp-logging-interceptor"
     },
     {
         "name": "Coil",

--- a/feature/settings/src/main/assets/oss_licenses.json
+++ b/feature/settings/src/main/assets/oss_licenses.json
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "Circuit",
+        "license": "Apache License 2.0",
+        "url": "https://github.com/slackhq/circuit"
+    },
+    {
+        "name": "Compose Effects",
+        "license": "Apache License 2.0",
+        "url": "https://github.com/skydoves/compose-effects"
+    },
+    {
+        "name": "Compose Stable Marker",
+        "license": "Apache License 2.0",
+        "url": "https://github.com/skydoves/compose-stable-marker"
+    },
+    {
+        "name": "Hilt",
+        "license": "Apache License 2.0",
+        "url": "https://dagger.dev/hilt/"
+    },
+    {
+        "name": "Kakao SDK",
+        "license": "Apache License 2.0",
+        "url": "https://developers.kakao.com/sdk/reference/android"
+    },
+    {
+        "name": "Logger",
+        "license": "Apache License 2.0",
+        "url": "https://github.com/orhanobut/logger"
+    },
+    {
+        "name": "OkHttp",
+        "license": "Apache License 2.0",
+        "url": "https://square.github.io/okhttp/"
+    },
+    {
+        "name": "Retrofit",
+        "license": "Apache License 2.0",
+        "url": "https://square.github.io/retrofit/"
+    }
+]

--- a/feature/settings/src/main/assets/oss_licenses.json
+++ b/feature/settings/src/main/assets/oss_licenses.json
@@ -20,11 +20,6 @@
         "url": "https://dagger.dev/hilt/"
     },
     {
-        "name": "Kakao SDK",
-        "license": "Apache License 2.0",
-        "url": "https://developers.kakao.com/sdk/reference/android"
-    },
-    {
         "name": "Logger",
         "license": "Apache License 2.0",
         "url": "https://github.com/orhanobut/logger"
@@ -38,5 +33,25 @@
         "name": "Retrofit",
         "license": "Apache License 2.0",
         "url": "https://square.github.io/retrofit/"
+    },
+    {
+        "name": "OkHttp Logging Interceptor",
+        "license": "Apache License 2.0",
+        "url": "https://square.github.io/okhttp/"
+    },
+    {
+        "name": "Coil",
+        "license": "Apache License 2.0",
+        "url": "https://github.com/coil-kt/coil"
+    },
+    {
+        "name": "Detekt",
+        "license": "Apache License 2.0",
+        "url": "https://github.com/detekt/detekt"
+    },
+    {
+        "name": "ktlint",
+        "license": "MIT License",
+        "url": "https://github.com/pinterest/ktlint"
     }
 ]

--- a/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/SettingsPresenter.kt
+++ b/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/SettingsPresenter.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import com.ninecraft.booket.screens.OssLicensesScreen
 import com.ninecraft.booket.screens.SettingsScreen
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.retained.rememberRetained
@@ -32,6 +33,10 @@ class SettingsPresenter @AssistedInject constructor(
 
                 is SettingsUiEvent.OnTermDetailClick -> {
                     // TODO: 웹뷰 화면으로 이동
+                }
+
+                is SettingsUiEvent.OnOssLicensesClick -> {
+                    navigator.goTo(OssLicensesScreen)
                 }
 
                 is SettingsUiEvent.OnLogoutClick -> {

--- a/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/SettingsScreen.kt
@@ -95,7 +95,7 @@ internal fun Settings(
         SettingItem(
             title = stringResource(R.string.settings_open_source_license),
             onItemClick = {
-                state.eventSink(SettingsUiEvent.OnTermDetailClick(""))
+                state.eventSink(SettingsUiEvent.OnOssLicensesClick)
             },
             action = {
                 Icon(

--- a/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/SettingsScreen.kt
@@ -60,7 +60,7 @@ internal fun Settings(
     ) {
         ReedBackTopAppBar(
             title = stringResource(R.string.settings_title),
-            onNavigateBack = {
+            onBackClick = {
                 state.eventSink(SettingsUiEvent.OnBackClick)
             },
         )

--- a/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/SettingsUiState.kt
@@ -13,6 +13,7 @@ data class SettingsUiState(
 sealed interface SettingsUiEvent : CircuitUiEvent {
     data object OnBackClick : SettingsUiEvent
     data class OnTermDetailClick(val title: String) : SettingsUiEvent
+    data object OnOssLicensesClick : SettingsUiEvent
     data object OnLogoutClick : SettingsUiEvent
     data object OnWithdrawClick : SettingsUiEvent
     data object OnBottomSheetDismissed : SettingsUiEvent

--- a/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/osslicenses/OssLicenseInfo.kt
+++ b/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/osslicenses/OssLicenseInfo.kt
@@ -1,0 +1,10 @@
+package com.ninecraft.booket.feature.settings.osslicenses
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OssLicenseInfo(
+    val name: String,
+    val license: String,
+    val url: String,
+)

--- a/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/osslicenses/OssLicensesPresenter.kt
+++ b/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/osslicenses/OssLicensesPresenter.kt
@@ -1,0 +1,35 @@
+package com.ninecraft.booket.feature.settings.osslicenses
+
+import androidx.compose.runtime.Composable
+import com.ninecraft.booket.screens.OssLicensesScreen
+import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.components.ActivityRetainedComponent
+
+class OssLicensesPresenter @AssistedInject constructor(
+    @Assisted val navigator: Navigator,
+) : Presenter<OssLicensesUiState> {
+    @Composable
+    override fun present(): OssLicensesUiState {
+        fun handleEvent(event: OssLicensesUiEvent) {
+            when (event) {
+                is OssLicensesUiEvent.OnBackClicked -> {
+                    navigator.pop()
+                }
+            }
+        }
+        return OssLicensesUiState(
+            eventSink = ::handleEvent,
+        )
+    }
+
+    @CircuitInject(OssLicensesScreen::class, ActivityRetainedComponent::class)
+    @AssistedFactory
+    fun interface Factory {
+        fun create(navigator: Navigator): OssLicensesPresenter
+    }
+}

--- a/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/osslicenses/OssLicensesScreen.kt
+++ b/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/osslicenses/OssLicensesScreen.kt
@@ -83,10 +83,10 @@ internal fun OssLicenses(
 
 @Composable
 private fun OssLicenseItem(
+    name: String,
+    license: String,
+    url: String,
     modifier: Modifier = Modifier,
-    name: String = "",
-    license: String = "",
-    url: String = "",
 ) {
     Column(
         modifier = modifier

--- a/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/osslicenses/OssLicensesScreen.kt
+++ b/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/osslicenses/OssLicensesScreen.kt
@@ -65,7 +65,7 @@ internal fun OssLicenses(
     ) {
         ReedBackTopAppBar(
             title = stringResource(R.string.oss_licenses_title),
-            onNavigateBack = {
+            onBackClick = {
                 state.eventSink(OssLicensesUiEvent.OnBackClicked)
             },
         )

--- a/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/osslicenses/OssLicensesScreen.kt
+++ b/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/osslicenses/OssLicensesScreen.kt
@@ -1,0 +1,159 @@
+package com.ninecraft.booket.feature.settings.osslicenses
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import com.ninecraft.booket.core.designsystem.DevicePreview
+import com.ninecraft.booket.core.designsystem.component.appbar.ReedBackTopAppBar
+import com.ninecraft.booket.core.designsystem.theme.ReedTheme
+import com.ninecraft.booket.core.designsystem.theme.White
+import com.ninecraft.booket.feature.settings.R
+import com.ninecraft.booket.screens.OssLicensesScreen
+import com.orhanobut.logger.Logger
+import com.slack.circuit.codegen.annotations.CircuitInject
+import dagger.hilt.android.components.ActivityRetainedComponent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import java.io.IOException
+
+@CircuitInject(OssLicensesScreen::class, ActivityRetainedComponent::class)
+@Composable
+internal fun OssLicenses(
+    state: OssLicensesUiState,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    var licenses by remember { mutableStateOf<List<OssLicenseInfo>>(emptyList()) }
+
+    LaunchedEffect(Unit) {
+        licenses = withContext(Dispatchers.IO) {
+            getOssLicensesDataFromAsset(context)
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(White),
+    ) {
+        ReedBackTopAppBar(
+            title = stringResource(R.string.oss_licenses_title),
+            onNavigateBack = {
+                state.eventSink(OssLicensesUiEvent.OnBackClicked)
+            },
+        )
+        LazyColumn {
+            items(licenses) { license ->
+                OssLicenseItem(
+                    name = license.name,
+                    license = license.license,
+                    url = license.url,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OssLicenseItem(
+    modifier: Modifier = Modifier,
+    name: String = "",
+    license: String = "",
+    url: String = "",
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = ReedTheme.spacing.spacing3,
+                vertical = ReedTheme.spacing.spacing3,
+            ),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(ReedTheme.spacing.spacing1)
+                    .background(
+                        color = ReedTheme.colors.contentBrand,
+                        shape = CircleShape,
+                    ),
+            )
+            Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing1))
+            Text(
+                text = "$name - $license",
+                fontWeight = FontWeight.W500,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+                style = ReedTheme.typography.caption2Regular,
+            )
+        }
+        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
+        Text(
+            text = url,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = ReedTheme.colors.bgSecondary,
+                    shape = RoundedCornerShape(ReedTheme.radius.xs),
+                )
+                .padding(
+                    horizontal = ReedTheme.spacing.spacing2,
+                    vertical = ReedTheme.spacing.spacing4,
+                ),
+            style = ReedTheme.typography.caption2Regular,
+        )
+    }
+}
+
+private fun getOssLicensesDataFromAsset(context: Context): List<OssLicenseInfo> {
+    return try {
+        val json = context.assets.open("oss_licenses.json")
+            .bufferedReader()
+            .use { it.readText() }
+        Json.decodeFromString(json)
+    } catch (e: IOException) {
+        Logger.e(e, "Failed to read json file")
+        emptyList()
+    }
+}
+
+@DevicePreview
+@Composable
+private fun OssLicensesScreenPreview() {
+    ReedTheme {
+        OssLicenses(
+            state = OssLicensesUiState(
+                eventSink = {},
+            ),
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/osslicenses/OssLicensesUiState.kt
+++ b/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/osslicenses/OssLicensesUiState.kt
@@ -1,0 +1,12 @@
+package com.ninecraft.booket.feature.settings.osslicenses
+
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+
+data class OssLicensesUiState(
+    val eventSink: (OssLicensesUiEvent) -> Unit,
+) : CircuitUiState
+
+sealed interface OssLicensesUiEvent : CircuitUiEvent {
+    data object OnBackClicked : OssLicensesUiEvent
+}

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -13,4 +13,5 @@
     <string name="settings_withdraw_agreement">확인하였으며 이에 동의합니다.</string>
     <string name="settings_cancel">취소</string>
     <string name="settings_withdraw_action">탈퇴하기</string>
+    <string name="oss_licenses_title">오픈소스 라이선스</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -116,12 +116,8 @@ detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-form
 
 kakao-auth = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakao-core" }
 
-junit = { group = "junit", name = "junit", version.ref = "junit" }
-
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-test-runner" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 [plugins]
 gradle-dependency-handler-extensions = { id = "land.sungbin.dependency.handler.extensions", version.ref = "gradle-dependency-handler-extensions" }

--- a/screens/src/main/kotlin/com/ninecraft/booket/screens/Screens.kt
+++ b/screens/src/main/kotlin/com/ninecraft/booket/screens/Screens.kt
@@ -24,3 +24,6 @@ data object TermsAgreementScreen : ReedScreen(name = "TermsAgreement()")
 
 @Parcelize
 data object SettingsScreen : ReedScreen(name = "Settings()")
+
+@Parcelize
+data object OssLicensesScreen : ReedScreen(name = "OssLicenses()")


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #44 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- settings 모듈 assets에 OSS 정보 .json 파일 추가
- 오픈소스 라이선스 화면 UI 작업
- `clickableSingle`ripple 색상 이슈 해결


## 📸 스크린샷 또는 시연 영상
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

https://github.com/user-attachments/assets/eec184e3-aa1c-4a91-9242-ef13948e0f97



## 💬 추가 설명 or 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- [oss-licenses](https://developers.google.com/android/guides/opensource?hl=ko) 라이브러리를 사용해서 구현하려고 했으나 디자인 구림, 사용중인 라이브러리 데이터 정확성 떨어짐, build.gradle의 `gradleLocalProperties` 함수와 충돌 등의 이유로 직접 구현했습니다.
(아래는 해당 라이브러리를 프로젝트에 사용했을 때의 이미지입니다)
<img width="200" alt="image" src="https://github.com/user-attachments/assets/84a4f04e-8c01-46c2-832a-d12fbd3d6726" />

- 지금은 로컬에 .json 데이터를 넣어서 임시로 구현해 놓은 것에 가깝지만, 추후 톡에서 얘기했던 것처럼 remote 데이터로 관리하면 될 것 같습니다.
- clickableSingle에서 `indication`에 지정한 `LocalIndication.current`를 통해 RippleTheme를 적용하지 못하는 문제가 있었습니다. [공식문서](https://developer.android.com/develop/ui/compose/touch-input/user-interactions/migrate-indication-ripple?hl=ko#migrate-remember-ripple)를 확인해보니 M3 이전에는 `rememberRipple()` 함수를 통해 RippleTheme의 효과를 사용했으며, M3부터는 `ripple()` api를 사용하라고 가이드 되어있어 해당 부분 적용했습니다~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 설정 화면에 오픈소스 라이선스 목록을 확인할 수 있는 화면이 추가되었습니다.
  * 오픈소스 라이선스 화면에서 각 라이브러리의 이름, 라이선스 종류, URL을 확인할 수 있습니다.
  * 설정에서 "오픈소스 라이선스" 항목을 클릭하면 해당 화면으로 이동합니다.

* **스타일**
  * 앱바 제목의 텍스트 스타일이 개선되었습니다.
  * 클릭 시 머티리얼3 리플 효과가 적용되어 시각적 피드백이 향상되었습니다.

* **문서화**
  * 오픈소스 라이선스 관련 JSON 파일 및 문자열 리소스가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->