### PR TITLE
refactor: 로그인/로그아웃 로직 개선

### DIFF
--- a/core/data/api/src/main/kotlin/com/ninecraft/booket/core/data/api/repository/AuthRepository.kt
+++ b/core/data/api/src/main/kotlin/com/ninecraft/booket/core/data/api/repository/AuthRepository.kt
@@ -1,10 +1,6 @@
 package com.ninecraft.booket.core.data.api.repository
 
-import com.ninecraft.booket.core.model.LoginModel
-
 interface AuthRepository {
-    suspend fun login(accessToken: String): Result<LoginModel>
+    suspend fun login(accessToken: String): Result<Unit>
     suspend fun logout(): Result<Unit>
-    suspend fun saveTokens(accessToken: String, refreshToken: String)
-    suspend fun clearTokens()
 }

--- a/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/mapper/ResponseToModel.kt
+++ b/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/mapper/ResponseToModel.kt
@@ -4,20 +4,12 @@ import com.ninecraft.booket.core.common.extensions.decodeHtmlEntities
 import com.ninecraft.booket.core.model.BookDetailModel
 import com.ninecraft.booket.core.model.BookSearchModel
 import com.ninecraft.booket.core.model.BookSummaryModel
-import com.ninecraft.booket.core.model.LoginModel
 import com.ninecraft.booket.core.model.UserProfileModel
 import com.ninecraft.booket.core.network.response.BookDetailResponse
 import com.ninecraft.booket.core.network.response.BookSearchResponse
 import com.ninecraft.booket.core.network.response.BookSummary
 import com.ninecraft.booket.core.network.response.LoginResponse
 import com.ninecraft.booket.core.network.response.UserProfileResponse
-
-internal fun LoginResponse.toModel(): LoginModel {
-    return LoginModel(
-        accessToken = accessToken,
-        refreshToken = refreshToken,
-    )
-}
 
 internal fun UserProfileResponse.toModel(): UserProfileModel {
     return UserProfileModel(

--- a/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/mapper/ResponseToModel.kt
+++ b/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/mapper/ResponseToModel.kt
@@ -8,7 +8,6 @@ import com.ninecraft.booket.core.model.UserProfileModel
 import com.ninecraft.booket.core.network.response.BookDetailResponse
 import com.ninecraft.booket.core.network.response.BookSearchResponse
 import com.ninecraft.booket.core.network.response.BookSummary
-import com.ninecraft.booket.core.network.response.LoginResponse
 import com.ninecraft.booket.core.network.response.UserProfileResponse
 
 internal fun UserProfileResponse.toModel(): UserProfileModel {

--- a/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/repository/DefaultAuthRepository.kt
+++ b/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/repository/DefaultAuthRepository.kt
@@ -2,7 +2,6 @@ package com.ninecraft.booket.core.data.impl.repository
 
 import com.ninecraft.booket.core.common.utils.runSuspendCatching
 import com.ninecraft.booket.core.data.api.repository.AuthRepository
-import com.ninecraft.booket.core.data.impl.mapper.toModel
 import com.ninecraft.booket.core.datastore.api.datasource.TokenPreferencesDataSource
 import com.ninecraft.booket.core.network.request.LoginRequest
 import com.ninecraft.booket.core.network.service.AuthService
@@ -17,26 +16,28 @@ internal class DefaultAuthRepository @Inject constructor(
     private val tokenDatasource: TokenPreferencesDataSource,
 ) : AuthRepository {
     override suspend fun login(accessToken: String) = runSuspendCatching {
-        noAuthService.login(
+        val response = noAuthService.login(
             LoginRequest(
                 providerType = KAKAO_PROVIDER_TYPE,
                 oauthToken = accessToken,
             ),
-        ).toModel()
+        )
+        saveTokens(response.accessToken, response.refreshToken)
     }
 
     override suspend fun logout() = runSuspendCatching {
         authService.logout()
+        clearTokens()
     }
 
-    override suspend fun saveTokens(accessToken: String, refreshToken: String) {
+    private suspend fun saveTokens(accessToken: String, refreshToken: String) {
         tokenDatasource.apply {
             setAccessToken(accessToken)
             setRefreshToken(refreshToken)
         }
     }
 
-    override suspend fun clearTokens() {
+    private suspend fun clearTokens() {
         tokenDatasource.clearTokens()
     }
 }

--- a/core/model/src/main/kotlin/com/ninecraft/booket/core/model/LoginModel.kt
+++ b/core/model/src/main/kotlin/com/ninecraft/booket/core/model/LoginModel.kt
@@ -1,6 +1,0 @@
-package com.ninecraft.booket.core.model
-
-data class LoginModel(
-    val accessToken: String,
-    val refreshToken: String,
-)

--- a/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryPresenter.kt
+++ b/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryPresenter.kt
@@ -87,7 +87,6 @@ class LibraryPresenter @AssistedInject constructor(
                             isLoading = true
                             authRepository.logout()
                                 .onSuccess {
-                                    authRepository.clearTokens()
                                     navigator.resetRoot(LoginScreen)
                                 }
                                 .onFailure { exception ->

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/login/LoginPresenter.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/login/LoginPresenter.kt
@@ -49,9 +49,9 @@ class LoginPresenter @AssistedInject constructor(
                 is LoginUiEvent.Login -> {
                     scope.launch {
                         try {
+                            isLoading = true
                             repository.login(event.accessToken)
-                                .onSuccess { result ->
-                                    repository.saveTokens(result.accessToken, result.refreshToken)
+                                .onSuccess {
                                     navigator.goTo(TermsAgreementScreen)
                                 }.onFailure { exception ->
                                     exception.message?.let { Logger.e(it) }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close https://github.com/YAPP-Github/Reed-Android/issues/47

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 굳이 dataStore를 통한 access,refreshToken 저장 및 삭제 로직을 Presenter까지 올려서 구현할 필요가 없다고 생각 -> Repository에서 처리하는 방식으로 변경

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- https://github.com/YAPP-Github/Reed-Android/pull/30
<img width="846" height="863" alt="image" src="https://github.com/user-attachments/assets/d0d200af-051b-4cbb-a797-136e0c6496c0" />

- 제가 runSuspendCatching...더 나아가 runCatching 아니 그것보다 이전에 try~catch에 대한 + suspend 함수내 suspend 함수들의 실행 순서에 대한 이해가 부족해서 위와 같은 경솔한 발언을 했었슴니다 ;ㅁ;

- suspend 함수내에 suspend 함수들은 순차적으로 실행되며, api 호출 함수가 터지면 HttpException을 뱉고 failure 를 타게 되어서, access/refreshToken 저장/삭제 로직을 타지않는게 맞슴니다. 

- 성공적으로 호출되면 토큰 처리까지 하고 Presenter로는 Success flag만 던져주면 되므로, Presenter에서는 Navigator 처리만ㅇㅇ
기존 Presenter의 너무 많은 책임이 있던 문제를 해결할 수 있었슴다 
