### PR TITLE
feat: 독서 기록 플로우 화면 - 감상평, 감정선택 UI 구현

### DIFF
--- a/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/RecordStep.kt
+++ b/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/RecordStep.kt
@@ -1,9 +1,9 @@
 package com.ninecraft.booket.core.designsystem
 
 enum class RecordStep {
-    REGISTER,
-    APPRECIATION,
+    QUOTE,
     EMOTION,
+    IMPRESSION,
     ;
 
     val value: Int get() = ordinal

--- a/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/RecordProgressBar.kt
+++ b/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/RecordProgressBar.kt
@@ -30,7 +30,7 @@ fun RecordProgressBar(
                     .height(6.dp)
                     .clip(RoundedCornerShape(ReedTheme.radius.full))
                     .background(
-                        color = if (currentStep.value == index) {
+                        color = if (index <= currentStep.ordinal) {
                             ReedTheme.colors.bgPrimary
                         } else {
                             ReedTheme.colors.bgDisabled

--- a/core/network/src/main/kotlin/com/ninecraft/booket/core/network/service/ReedService.kt
+++ b/core/network/src/main/kotlin/com/ninecraft/booket/core/network/service/ReedService.kt
@@ -59,6 +59,6 @@ interface ReedService {
         @Query("status") status: String? = null,
         @Query("page") page: Int,
         @Query("size") size: Int,
-        @Query("sort") sort: String = "date_desc",
+        @Query("sort") sort: String = "CREATED_DATE_DESC",
     ): LibraryResponse
 }

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBottomSheet.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBottomSheet.kt
@@ -1,0 +1,148 @@
+package com.ninecraft.booket.feature.record.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
+import com.ninecraft.booket.core.common.extensions.clickableSingle
+import com.ninecraft.booket.core.designsystem.ComponentPreview
+import com.ninecraft.booket.core.designsystem.component.button.ReedButton
+import com.ninecraft.booket.core.designsystem.component.button.ReedButtonColorStyle
+import com.ninecraft.booket.core.designsystem.component.button.largeButtonStyle
+import com.ninecraft.booket.core.designsystem.theme.ReedTheme
+import com.ninecraft.booket.core.ui.component.ReedBottomSheet
+import com.ninecraft.booket.feature.record.R
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toPersistentList
+import com.ninecraft.booket.core.designsystem.R as designR
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ImpressionGuideBottomSheet(
+    onDismissRequest: () -> Unit,
+    sheetState: SheetState,
+    impressionGuideList: ImmutableList<String>,
+    selectedImpressionGuide: String,
+    onGuideClick: (Int) -> Unit,
+    onCloseButtonClick: () -> Unit,
+    onSelectionConfirmButtonClick: () -> Unit,
+) {
+    ReedBottomSheet(
+        onDismissRequest = {
+            onDismissRequest()
+        },
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(
+                    start = ReedTheme.spacing.spacing5,
+                    top = ReedTheme.spacing.spacing5,
+                    end = ReedTheme.spacing.spacing5,
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = stringResource(R.string.impression_guide_bottomsheet_title),
+                    color = ReedTheme.colors.contentPrimary,
+                    textAlign = TextAlign.Center,
+                    style = ReedTheme.typography.heading2SemiBold,
+                )
+                Icon(
+                    imageVector = ImageVector.vectorResource(designR.drawable.ic_close),
+                    contentDescription = "Close Icon",
+                    modifier = Modifier.clickableSingle {
+                        onCloseButtonClick()
+                    },
+                )
+            }
+            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
+            Text(
+                text = stringResource(R.string.impression_guide_bottomsheet_description),
+                modifier = Modifier.fillMaxWidth(),
+                color = ReedTheme.colors.contentPrimary,
+                style = ReedTheme.typography.label1Medium,
+            )
+            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing5))
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(ReedTheme.spacing.spacing2),
+            ) {
+                impressionGuideList.forEachIndexed { index, guide ->
+                    ImpressionGuideBox(
+                        onClick = {
+                            onGuideClick(index)
+                        },
+                        impressionText = guide,
+                        isSelected = selectedImpressionGuide == guide
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing3))
+            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing4))
+            ReedButton(
+                onClick = {
+                    onSelectionConfirmButtonClick()
+                },
+                sizeStyle = largeButtonStyle,
+                colorStyle = ReedButtonColorStyle.PRIMARY,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = selectedImpressionGuide.isNotEmpty(),
+                text = stringResource(R.string.impression_guide_bottomsheet_selection_confirm),
+            )
+            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing4))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@ComponentPreview
+@Composable
+private fun ImpressionGuideBottomSheetPreview() {
+    val sheetState = SheetState(
+        skipPartiallyExpanded = true,
+        initialValue = SheetValue.Expanded,
+        positionalThreshold = { 0f },
+        velocityThreshold = { 0f },
+    )
+    val impressionGuideList = listOf(
+        "에서 위로 받았다",
+        "이 마음에 남았다",
+        "에서 작가의 의도가 궁금하다",
+        "에 대한 다른 사람들의 생각이 궁금하다",
+        "에서 크게 공감이 된다",
+        "을 보고 예전 기억이 났다",
+        "에서 문장에 머물렀다",
+    ).toPersistentList()
+
+    ReedTheme {
+        ImpressionGuideBottomSheet(
+            onDismissRequest = {},
+            sheetState = sheetState,
+            impressionGuideList = impressionGuideList,
+            selectedImpressionGuide = "",
+            onGuideClick = {},
+            onCloseButtonClick = {},
+            onSelectionConfirmButtonClick = {},
+        )
+    }
+}

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBottomSheet.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBottomSheet.kt
@@ -93,7 +93,7 @@ fun ImpressionGuideBottomSheet(
                             onGuideClick(index)
                         },
                         impressionText = guide,
-                        isSelected = selectedImpressionGuide == guide
+                        isSelected = selectedImpressionGuide == guide,
                     )
                 }
             }

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBox.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBox.kt
@@ -1,0 +1,81 @@
+package com.ninecraft.booket.feature.record.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.ninecraft.booket.core.common.extensions.clickableSingle
+import com.ninecraft.booket.core.designsystem.ComponentPreview
+import com.ninecraft.booket.core.designsystem.theme.ReedTheme
+import com.ninecraft.booket.core.designsystem.theme.White
+import com.ninecraft.booket.feature.record.R
+
+@Composable
+fun ImpressionGuideBox(
+    onClick: () -> Unit,
+    impressionText: String,
+    modifier: Modifier = Modifier,
+    isSelected: Boolean = false,
+) {
+    val bgColor = if (isSelected) ReedTheme.colors.bgTertiary else White
+    val borderColor = if (isSelected) ReedTheme.colors.borderBrand else ReedTheme.colors.borderPrimary
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = bgColor,
+                shape = RoundedCornerShape(ReedTheme.radius.sm),
+            )
+            .border(
+                width = 1.dp,
+                color = borderColor,
+                shape = RoundedCornerShape(ReedTheme.radius.sm),
+            )
+            .clip(RoundedCornerShape(ReedTheme.radius.sm))
+            .clickableSingle {
+                onClick()
+            }
+            .padding(
+                horizontal = ReedTheme.spacing.spacing4,
+                vertical = ReedTheme.spacing.spacing4,
+            ),
+    ) {
+        Row(
+            verticalAlignment = Alignment.Bottom
+        ) {
+            Text(
+                text = stringResource(R.string.impression_guide_blank),
+                color = Color(0xFFD6D6D6),
+                style = ReedTheme.typography.label1SemiBold,
+            )
+            Text(
+                text = impressionText,
+                color = ReedTheme.colors.contentPrimary,
+                style = ReedTheme.typography.label1SemiBold,
+            )
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun ImpressionGuideBoxPreview() {
+    ReedTheme {
+        ImpressionGuideBox(
+            onClick = {},
+            impressionText = "에서 위로 받았다",
+        )
+    }
+}

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBox.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBox.kt
@@ -52,9 +52,7 @@ fun ImpressionGuideBox(
                 vertical = ReedTheme.spacing.spacing4,
             ),
     ) {
-        Row(
-            verticalAlignment = Alignment.Bottom
-        ) {
+        Row(verticalAlignment = Alignment.Bottom) {
             Text(
                 text = stringResource(R.string.impression_guide_blank),
                 color = Color(0xFFD6D6D6),

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
@@ -77,9 +77,7 @@ class RecordRegisterPresenter @AssistedInject constructor(
 
                 is RecordRegisterUiEvent.OnSentenceScanButtonClick -> {}
 
-                is RecordRegisterUiEvent.OnSelectEmotion -> {
-
-                }
+                is RecordRegisterUiEvent.OnSelectEmotion -> {}
 
                 is RecordRegisterUiEvent.OnImpressionGuideButtonClick -> {
                     selectedImpressionGuide = ""
@@ -100,9 +98,7 @@ class RecordRegisterPresenter @AssistedInject constructor(
                     }
                 }
 
-                is RecordRegisterUiEvent.OnSelectionConfirmed -> {
-
-                }
+                is RecordRegisterUiEvent.OnSelectionConfirmed -> {}
 
                 is RecordRegisterUiEvent.OnImpressionGuideBottomSheetDismiss -> {
                     isImpressionGuideBottomSheetVisible = false

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import com.ninecraft.booket.core.designsystem.RecordStep
 import com.ninecraft.booket.feature.screens.RecordScreen
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.retained.rememberRetained
@@ -18,18 +19,32 @@ import dagger.hilt.android.components.ActivityRetainedComponent
 
 class RecordRegisterPresenter @AssistedInject constructor(
     @Assisted private val navigator: Navigator,
-) : Presenter<RecordUiState> {
+) : Presenter<RecordRegisterUiState> {
 
     @Composable
-    override fun present(): RecordUiState {
+    override fun present(): RecordRegisterUiState {
+        var currentStep by rememberRetained { mutableStateOf(RecordStep.QUOTE) }
         val recordPageState = rememberTextFieldState()
         val recordSentenceState = rememberTextFieldState()
+        val impressionState = rememberTextFieldState()
         var isExitDialogVisible by rememberRetained { mutableStateOf(false) }
 
         fun handleEvent(event: RecordRegisterUiEvent) {
             when (event) {
                 is RecordRegisterUiEvent.OnBackButtonClick -> {
-                    isExitDialogVisible = true
+                    when (currentStep) {
+                        RecordStep.QUOTE -> {
+                            isExitDialogVisible = true
+                        }
+
+                        RecordStep.EMOTION -> {
+                            currentStep = RecordStep.QUOTE
+                        }
+
+                        RecordStep.IMPRESSION -> {
+                            currentStep = RecordStep.EMOTION
+                        }
+                    }
                 }
 
                 is RecordRegisterUiEvent.OnClearClick -> {
@@ -45,13 +60,29 @@ class RecordRegisterPresenter @AssistedInject constructor(
                 }
 
                 is RecordRegisterUiEvent.OnSentenceScanButtonClick -> {}
-                is RecordRegisterUiEvent.OnNextButtonClick -> {}
+                is RecordRegisterUiEvent.OnNextButtonClick -> {
+                    when (currentStep) {
+                        RecordStep.QUOTE -> {
+                            currentStep = RecordStep.EMOTION
+                        }
+
+                        RecordStep.EMOTION -> {
+                            currentStep = RecordStep.IMPRESSION
+                        }
+
+                        RecordStep.IMPRESSION -> {
+                            // TODO: (기록 완료 API 성공 시) 기록 상세 화면 이동
+                        }
+                    }
+                }
             }
         }
 
-        return RecordUiState(
+        return RecordRegisterUiState(
+            currentStep = currentStep,
             recordPageState = recordPageState,
             recordSentenceState = recordSentenceState,
+            impressionState = impressionState,
             isExitDialogVisible = isExitDialogVisible,
             eventSink = ::handleEvent,
         )

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
@@ -16,6 +16,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.components.ActivityRetainedComponent
+import kotlinx.collections.immutable.toPersistentList
 
 class RecordRegisterPresenter @AssistedInject constructor(
     @Assisted private val navigator: Navigator,
@@ -26,7 +27,22 @@ class RecordRegisterPresenter @AssistedInject constructor(
         var currentStep by rememberRetained { mutableStateOf(RecordStep.QUOTE) }
         val recordPageState = rememberTextFieldState()
         val recordSentenceState = rememberTextFieldState()
+        val impressionGuideList by rememberRetained {
+            mutableStateOf(
+                listOf(
+                    "에서 위로 받았다",
+                    "이 마음에 남았다",
+                    "에서 작가의 의도가 궁금하다",
+                    "에 대한 다른 사람들의 생각이 궁금하다",
+                    "에서 크게 공감이 된다",
+                    "을 보고 예전 기억이 났다",
+                    "에서 문장에 머물렀다",
+                ).toPersistentList(),
+            )
+        }
+        var selectedImpressionGuide by rememberRetained { mutableStateOf("") }
         val impressionState = rememberTextFieldState()
+        var isImpressionGuideBottomSheetVisible by rememberRetained { mutableStateOf(false) }
         var isExitDialogVisible by rememberRetained { mutableStateOf(false) }
 
         fun handleEvent(event: RecordRegisterUiEvent) {
@@ -60,6 +76,38 @@ class RecordRegisterPresenter @AssistedInject constructor(
                 }
 
                 is RecordRegisterUiEvent.OnSentenceScanButtonClick -> {}
+
+                is RecordRegisterUiEvent.OnSelectEmotion -> {
+
+                }
+
+                is RecordRegisterUiEvent.OnImpressionGuideButtonClick -> {
+                    selectedImpressionGuide = ""
+                    impressionState.edit {
+                        replace(0, length, "")
+                    }
+                    isImpressionGuideBottomSheetVisible = true
+                }
+
+                is RecordRegisterUiEvent.OnSelectImpressionGuide -> {
+                    val index = event.index
+                    if (index in impressionGuideList.indices) {
+                        selectedImpressionGuide = impressionGuideList[index]
+                        impressionState.edit {
+                            replace(0, length, "")
+                            append(selectedImpressionGuide)
+                        }
+                    }
+                }
+
+                is RecordRegisterUiEvent.OnSelectionConfirmed -> {
+
+                }
+
+                is RecordRegisterUiEvent.OnImpressionGuideBottomSheetDismiss -> {
+                    isImpressionGuideBottomSheetVisible = false
+                }
+
                 is RecordRegisterUiEvent.OnNextButtonClick -> {
                     when (currentStep) {
                         RecordStep.QUOTE -> {
@@ -83,7 +131,10 @@ class RecordRegisterPresenter @AssistedInject constructor(
             recordPageState = recordPageState,
             recordSentenceState = recordSentenceState,
             impressionState = impressionState,
+            impressionGuideList = impressionGuideList,
+            isImpressionGuideBottomSheetVisible = isImpressionGuideBottomSheetVisible,
             isExitDialogVisible = isExitDialogVisible,
+            selectedImpressionGuide = selectedImpressionGuide,
             eventSink = ::handleEvent,
         )
     }

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
@@ -56,7 +56,7 @@ internal fun RecordRegister(
             }
 
             RecordStep.EMOTION -> {
-                EmotionStep(state = state)
+                EmotionStep()
             }
 
             RecordStep.IMPRESSION -> {

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
@@ -1,51 +1,36 @@
 package com.ninecraft.booket.feature.record.register
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.input.TextFieldLineLimits
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import com.ninecraft.booket.core.designsystem.DevicePreview
 import com.ninecraft.booket.core.designsystem.RecordStep
 import com.ninecraft.booket.core.designsystem.component.RecordProgressBar
 import com.ninecraft.booket.core.designsystem.component.button.ReedButton
 import com.ninecraft.booket.core.designsystem.component.button.ReedButtonColorStyle
 import com.ninecraft.booket.core.designsystem.component.button.largeButtonStyle
-import com.ninecraft.booket.core.designsystem.component.button.smallRoundedButtonStyle
-import com.ninecraft.booket.core.designsystem.component.textfield.ReedRecordTextField
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
-import com.ninecraft.booket.core.designsystem.theme.White
 import com.ninecraft.booket.core.ui.component.ReedBackTopAppBar
 import com.ninecraft.booket.core.ui.component.ReedDialog
 import com.ninecraft.booket.core.ui.component.ReedFullScreen
 import com.ninecraft.booket.feature.record.R
+import com.ninecraft.booket.feature.record.step.EmotionStep
+import com.ninecraft.booket.feature.record.step.ImpressionStep
+import com.ninecraft.booket.feature.record.step.QuoteStep
 import com.ninecraft.booket.feature.screens.RecordScreen
 import com.slack.circuit.codegen.annotations.CircuitInject
 import dagger.hilt.android.components.ActivityRetainedComponent
-import com.ninecraft.booket.core.designsystem.R as designR
 
 @CircuitInject(RecordScreen::class, ActivityRetainedComponent::class)
 @Composable
 internal fun RecordRegister(
-    state: RecordUiState,
+    state: RecordRegisterUiState,
     modifier: Modifier = Modifier,
 ) {
     BackHandler {
@@ -60,7 +45,37 @@ internal fun RecordRegister(
                 state.eventSink(RecordRegisterUiEvent.OnBackButtonClick)
             },
         )
-        RecordRegisterContent(state = state)
+        RecordProgressBar(
+            currentStep = state.currentStep,
+            modifier = modifier.padding(horizontal = ReedTheme.spacing.spacing5),
+        )
+        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing10))
+        when (state.currentStep) {
+            RecordStep.QUOTE -> {
+                QuoteStep(state = state)
+            }
+
+            RecordStep.EMOTION -> {
+                EmotionStep(state = state)
+            }
+
+            RecordStep.IMPRESSION -> {
+                ImpressionStep(state = state)
+            }
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        ReedButton(
+            onClick = {
+                state.eventSink(RecordRegisterUiEvent.OnNextButtonClick)
+            },
+            colorStyle = ReedButtonColorStyle.PRIMARY,
+            sizeStyle = largeButtonStyle,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = ReedTheme.spacing.spacing5),
+            text = stringResource(R.string.record_next_button),
+        )
+        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing4))
     }
 
     if (state.isExitDialogVisible) {
@@ -79,107 +94,12 @@ internal fun RecordRegister(
     }
 }
 
-@Composable
-internal fun RecordRegisterContent(
-    state: RecordUiState,
-    modifier: Modifier = Modifier,
-) {
-    val focusManager = LocalFocusManager.current
-
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(White)
-            .padding(horizontal = ReedTheme.spacing.spacing5),
-    ) {
-        RecordProgressBar(
-            currentStep = RecordStep.REGISTER,
-            modifier = modifier,
-        )
-        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing10))
-        Text(
-            text = stringResource(R.string.record_register_title1),
-            color = ReedTheme.colors.contentPrimary,
-            style = ReedTheme.typography.heading1Bold,
-        )
-        Text(
-            text = stringResource(R.string.record_register_title2),
-            color = ReedTheme.colors.contentPrimary,
-            style = ReedTheme.typography.heading1Bold,
-        )
-        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing10))
-        Text(
-            text = stringResource(R.string.record_page_label),
-            color = ReedTheme.colors.contentPrimary,
-            style = ReedTheme.typography.body1Medium,
-        )
-        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
-        ReedRecordTextField(
-            recordState = state.recordPageState,
-            recordHintRes = R.string.record_page_hint,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number,
-                imeAction = ImeAction.Next,
-            ),
-            lineLimits = TextFieldLineLimits.SingleLine,
-            onClear = {
-                state.eventSink(RecordRegisterUiEvent.OnClearClick)
-            },
-            onNext = {
-                focusManager.moveFocus(FocusDirection.Down)
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(50.dp),
-        )
-        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing8))
-        Text(
-            text = stringResource(R.string.record_sentence_label),
-            color = ReedTheme.colors.contentPrimary,
-            style = ReedTheme.typography.body1Medium,
-        )
-        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
-        ReedRecordTextField(
-            recordState = state.recordSentenceState,
-            recordHintRes = R.string.record_sentence_hint,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(140.dp),
-        )
-        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing3))
-        ReedButton(
-            onClick = {},
-            colorStyle = ReedButtonColorStyle.STROKE,
-            sizeStyle = smallRoundedButtonStyle,
-            modifier = Modifier.align(Alignment.End),
-            text = stringResource(R.string.record_scan_sentence),
-            leadingIcon = {
-                Icon(
-                    imageVector = ImageVector.vectorResource(designR.drawable.ic_maximize),
-                    contentDescription = "Scan Icon",
-                )
-            },
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        ReedButton(
-            onClick = {
-                state.eventSink(RecordRegisterUiEvent.OnNextButtonClick)
-            },
-            colorStyle = ReedButtonColorStyle.PRIMARY,
-            sizeStyle = largeButtonStyle,
-            modifier = Modifier.fillMaxWidth(),
-            text = stringResource(R.string.record_next_button),
-        )
-        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing4))
-    }
-}
-
 @DevicePreview
 @Composable
 private fun RecordRegisterPreview() {
     ReedTheme {
         RecordRegister(
-            state = RecordUiState(
+            state = RecordRegisterUiState(
                 eventSink = {},
             ),
         )

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUiState.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUiState.kt
@@ -1,12 +1,15 @@
 package com.ninecraft.booket.feature.record.register
 
 import androidx.compose.foundation.text.input.TextFieldState
+import com.ninecraft.booket.core.designsystem.RecordStep
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 
-data class RecordUiState(
+data class RecordRegisterUiState(
+    val currentStep: RecordStep = RecordStep.QUOTE,
     val recordPageState: TextFieldState = TextFieldState(),
     val recordSentenceState: TextFieldState = TextFieldState(),
+    val impressionState: TextFieldState = TextFieldState(),
     val isExitDialogVisible: Boolean = false,
     val eventSink: (RecordRegisterUiEvent) -> Unit,
 ) : CircuitUiState

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUiState.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUiState.kt
@@ -4,12 +4,18 @@ import androidx.compose.foundation.text.input.TextFieldState
 import com.ninecraft.booket.core.designsystem.RecordStep
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 data class RecordRegisterUiState(
     val currentStep: RecordStep = RecordStep.QUOTE,
     val recordPageState: TextFieldState = TextFieldState(),
     val recordSentenceState: TextFieldState = TextFieldState(),
+    val selectedEmotion: String = "",
     val impressionState: TextFieldState = TextFieldState(),
+    val impressionGuideList: ImmutableList<String> = persistentListOf(),
+    val selectedImpressionGuide: String = "",
+    val isImpressionGuideBottomSheetVisible: Boolean = false,
     val isExitDialogVisible: Boolean = false,
     val eventSink: (RecordRegisterUiEvent) -> Unit,
 ) : CircuitUiState
@@ -19,6 +25,11 @@ sealed interface RecordRegisterUiEvent : CircuitUiEvent {
     data object OnClearClick : RecordRegisterUiEvent
     data object OnNextButtonClick : RecordRegisterUiEvent
     data object OnSentenceScanButtonClick : RecordRegisterUiEvent
+    data object OnSelectEmotion : RecordRegisterUiEvent
+    data object OnImpressionGuideButtonClick : RecordRegisterUiEvent
+    data object OnImpressionGuideBottomSheetDismiss : RecordRegisterUiEvent
+    data class OnSelectImpressionGuide(val index: Int) : RecordRegisterUiEvent
+    data object OnSelectionConfirmed : RecordRegisterUiEvent
     data object OnExitDialogConfirm : RecordRegisterUiEvent
     data object OnExitDialogDismiss : RecordRegisterUiEvent
 }

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/EmotionStep.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/EmotionStep.kt
@@ -1,0 +1,87 @@
+package com.ninecraft.booket.feature.record.step
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.ninecraft.booket.core.designsystem.ComponentPreview
+import com.ninecraft.booket.core.designsystem.theme.ReedTheme
+import com.ninecraft.booket.core.designsystem.theme.White
+import com.ninecraft.booket.feature.record.R
+import com.ninecraft.booket.feature.record.register.RecordRegisterUiState
+
+@Composable
+fun EmotionStep(
+    state: RecordRegisterUiState,
+    modifier: Modifier = Modifier,
+) {
+    val emotionList = listOf("기쁨", "슬픔", "분노", "놀람")
+    Column(
+        modifier = modifier
+            .background(White)
+            .padding(horizontal = ReedTheme.spacing.spacing5),
+    ) {
+        Text(
+            text = stringResource(R.string.emotion_step_title),
+            color = ReedTheme.colors.contentPrimary,
+            style = ReedTheme.typography.heading1Bold,
+        )
+        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing1))
+        Text(
+            text = stringResource(R.string.emotion_step_description),
+            color = ReedTheme.colors.contentTertiary,
+            style = ReedTheme.typography.label1Medium,
+        )
+        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing10))
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            verticalArrangement = Arrangement.spacedBy(ReedTheme.spacing.spacing3),
+            horizontalArrangement = Arrangement.spacedBy(ReedTheme.spacing.spacing3),
+            content = {
+                items(emotionList) { title ->
+                    EmotionItem(title)
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun EmotionItem(title: String) {
+    Box(
+        modifier = Modifier
+            .height(214.dp)
+            .background(
+                color = ReedTheme.colors.bgSecondary,
+                shape = RoundedCornerShape(ReedTheme.radius.md),
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(text = title)
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun RecordRegisterPreview() {
+    ReedTheme {
+        EmotionStep(
+            state = RecordRegisterUiState(
+                eventSink = {},
+            ),
+        )
+    }
+}

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/EmotionStep.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/EmotionStep.kt
@@ -21,11 +21,9 @@ import com.ninecraft.booket.core.designsystem.ComponentPreview
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
 import com.ninecraft.booket.core.designsystem.theme.White
 import com.ninecraft.booket.feature.record.R
-import com.ninecraft.booket.feature.record.register.RecordRegisterUiState
 
 @Composable
 fun EmotionStep(
-    state: RecordRegisterUiState,
     modifier: Modifier = Modifier,
 ) {
     val emotionList = listOf("기쁨", "슬픔", "분노", "놀람")
@@ -78,10 +76,6 @@ private fun EmotionItem(title: String) {
 @Composable
 private fun RecordRegisterPreview() {
     ReedTheme {
-        EmotionStep(
-            state = RecordRegisterUiState(
-                eventSink = {},
-            ),
-        )
+        EmotionStep()
     }
 }

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
@@ -121,4 +121,3 @@ private fun ImpressionStepPreview() {
         )
     }
 }
-

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
@@ -1,0 +1,85 @@
+package com.ninecraft.booket.feature.record.step
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import com.ninecraft.booket.core.designsystem.ComponentPreview
+import com.ninecraft.booket.core.designsystem.component.button.ReedButton
+import com.ninecraft.booket.core.designsystem.component.button.ReedButtonColorStyle
+import com.ninecraft.booket.core.designsystem.component.button.smallRoundedButtonStyle
+import com.ninecraft.booket.core.designsystem.component.textfield.ReedRecordTextField
+import com.ninecraft.booket.core.designsystem.theme.ReedTheme
+import com.ninecraft.booket.core.designsystem.theme.White
+import com.ninecraft.booket.feature.record.R
+import com.ninecraft.booket.feature.record.register.RecordRegisterUiState
+
+@Composable
+fun ImpressionStep(
+    state: RecordRegisterUiState,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .background(White)
+            .padding(horizontal = ReedTheme.spacing.spacing5),
+    ) {
+        Text(
+            text = stringResource(R.string.impression_step_title),
+            color = ReedTheme.colors.contentPrimary,
+            style = ReedTheme.typography.heading1Bold,
+        )
+        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing1))
+        Text(
+            text = stringResource(R.string.impression_step_description),
+            color = ReedTheme.colors.contentTertiary,
+            style = ReedTheme.typography.label1Medium,
+        )
+        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing10))
+        ReedRecordTextField(
+            recordState = state.impressionState,
+            recordHintRes = R.string.impression_step_hint,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(140.dp),
+        )
+        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing3))
+        ReedButton(
+            onClick = {},
+            colorStyle = ReedButtonColorStyle.STROKE,
+            sizeStyle = smallRoundedButtonStyle,
+            modifier = Modifier.align(Alignment.End),
+            text = "감상평 가이드",
+            leadingIcon = {
+                Icon(
+                    imageVector = ImageVector.vectorResource(com.ninecraft.booket.core.designsystem.R.drawable.ic_book_open),
+                    contentDescription = "Open Book Icon",
+                )
+            },
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun ImpressionStepPreview() {
+    ReedTheme {
+        ImpressionStep(
+            state = RecordRegisterUiState(
+                eventSink = {},
+            ),
+        )
+    }
+}
+

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
@@ -6,9 +6,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -23,13 +26,21 @@ import com.ninecraft.booket.core.designsystem.component.textfield.ReedRecordText
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
 import com.ninecraft.booket.core.designsystem.theme.White
 import com.ninecraft.booket.feature.record.R
+import com.ninecraft.booket.feature.record.component.ImpressionGuideBottomSheet
+import com.ninecraft.booket.feature.record.register.RecordRegisterUiEvent
 import com.ninecraft.booket.feature.record.register.RecordRegisterUiState
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ImpressionStep(
     state: RecordRegisterUiState,
     modifier: Modifier = Modifier,
 ) {
+    val coroutineScope = rememberCoroutineScope()
+    val impressionGuideBottomSheetState =
+        rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
     Column(
         modifier = modifier
             .background(White)
@@ -56,16 +67,44 @@ fun ImpressionStep(
         )
         Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing3))
         ReedButton(
-            onClick = {},
+            onClick = {
+                state.eventSink(RecordRegisterUiEvent.OnImpressionGuideButtonClick)
+            },
             colorStyle = ReedButtonColorStyle.STROKE,
             sizeStyle = smallRoundedButtonStyle,
             modifier = Modifier.align(Alignment.End),
-            text = "감상평 가이드",
+            text = stringResource(R.string.impression_step_guide),
             leadingIcon = {
                 Icon(
                     imageVector = ImageVector.vectorResource(com.ninecraft.booket.core.designsystem.R.drawable.ic_book_open),
-                    contentDescription = "Open Book Icon",
+                    contentDescription = "Impression Guide Icon",
                 )
+            },
+        )
+    }
+
+    if (state.isImpressionGuideBottomSheetVisible) {
+        ImpressionGuideBottomSheet(
+            onDismissRequest = {
+                state.eventSink(RecordRegisterUiEvent.OnImpressionGuideBottomSheetDismiss)
+            },
+            sheetState = impressionGuideBottomSheetState,
+            impressionGuideList = state.impressionGuideList,
+            selectedImpressionGuide = state.selectedImpressionGuide,
+            onGuideClick = {
+                state.eventSink(RecordRegisterUiEvent.OnSelectImpressionGuide(it))
+            },
+            onCloseButtonClick = {
+                coroutineScope.launch {
+                    impressionGuideBottomSheetState.hide()
+                    state.eventSink(RecordRegisterUiEvent.OnImpressionGuideBottomSheetDismiss)
+                }
+            },
+            onSelectionConfirmButtonClick = {
+                coroutineScope.launch {
+                    impressionGuideBottomSheetState.hide()
+                    state.eventSink(RecordRegisterUiEvent.OnImpressionGuideBottomSheetDismiss)
+                }
             },
         )
     }

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/QuoteStep.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/QuoteStep.kt
@@ -1,0 +1,120 @@
+package com.ninecraft.booket.feature.record.step
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.ninecraft.booket.core.designsystem.ComponentPreview
+import com.ninecraft.booket.core.designsystem.component.button.ReedButton
+import com.ninecraft.booket.core.designsystem.component.button.ReedButtonColorStyle
+import com.ninecraft.booket.core.designsystem.component.button.smallRoundedButtonStyle
+import com.ninecraft.booket.core.designsystem.component.textfield.ReedRecordTextField
+import com.ninecraft.booket.core.designsystem.theme.ReedTheme
+import com.ninecraft.booket.core.designsystem.theme.White
+import com.ninecraft.booket.feature.record.R
+import com.ninecraft.booket.feature.record.register.RecordRegisterUiEvent
+import com.ninecraft.booket.feature.record.register.RecordRegisterUiState
+
+@Composable
+internal fun QuoteStep(
+    state: RecordRegisterUiState,
+    modifier: Modifier = Modifier,
+) {
+    val focusManager = LocalFocusManager.current
+
+    Column(
+        modifier = modifier
+            .background(White)
+            .padding(horizontal = ReedTheme.spacing.spacing5),
+    ) {
+        Text(
+            text = stringResource(R.string.quote_step_title),
+            color = ReedTheme.colors.contentPrimary,
+            style = ReedTheme.typography.heading1Bold,
+        )
+        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing10))
+        Text(
+            text = stringResource(R.string.quote_step_page_label),
+            color = ReedTheme.colors.contentPrimary,
+            style = ReedTheme.typography.body1Medium,
+        )
+        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
+        ReedRecordTextField(
+            recordState = state.recordPageState,
+            recordHintRes = R.string.quote_step_page_hint,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Next,
+            ),
+            lineLimits = TextFieldLineLimits.SingleLine,
+            onClear = {
+                state.eventSink(RecordRegisterUiEvent.OnClearClick)
+            },
+            onNext = {
+                focusManager.moveFocus(FocusDirection.Down)
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(50.dp),
+        )
+        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing8))
+        Text(
+            text = stringResource(R.string.quote_step_sentence_label),
+            color = ReedTheme.colors.contentPrimary,
+            style = ReedTheme.typography.body1Medium,
+        )
+        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
+        ReedRecordTextField(
+            recordState = state.recordSentenceState,
+            recordHintRes = R.string.quote_step_sentence_hint,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(140.dp),
+        )
+        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing3))
+        ReedButton(
+            onClick = {
+                state.eventSink(RecordRegisterUiEvent.OnSentenceScanButtonClick)
+            },
+            colorStyle = ReedButtonColorStyle.STROKE,
+            sizeStyle = smallRoundedButtonStyle,
+            modifier = Modifier.align(Alignment.End),
+            text = stringResource(R.string.quote_step_scan_sentence),
+            leadingIcon = {
+                Icon(
+                    imageVector = ImageVector.vectorResource(com.ninecraft.booket.core.designsystem.R.drawable.ic_maximize),
+                    contentDescription = "Scan Icon",
+                )
+            },
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun QuoteStepPreview() {
+    ReedTheme {
+        QuoteStep(
+            state = RecordRegisterUiState(
+                eventSink = {},
+            ),
+        )
+    }
+}

--- a/feature/record/src/main/res/values/strings.xml
+++ b/feature/record/src/main/res/values/strings.xml
@@ -16,4 +16,9 @@
     <string name="impression_step_title">문장에 대한 감상을 남겨주세요</string>
     <string name="impression_step_description">감상평 가이드로 쉽게 남길 수 있어요</string>
     <string name="impression_step_hint">내용을 입력해주세요.</string>
+    <string name="impression_step_guide">감상평 가이드</string>
+    <string name="impression_guide_bottomsheet_title">감상평 가이드</string>
+    <string name="impression_guide_bottomsheet_description">아래 문장 중 하나를 선택해 이어서 감상을 적어보세요</string>
+    <string name="impression_guide_bottomsheet_selection_confirm">선택 완료</string>
+    <string name="impression_guide_blank">______</string>
 </resources>

--- a/feature/record/src/main/res/values/strings.xml
+++ b/feature/record/src/main/res/values/strings.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="record_register_title1">기록하고 싶은 페이지와</string>
-    <string name="record_register_title2">문장을 등록해보세요</string>
-    <string name="record_page_label">책 페이지</string>
-    <string name="record_sentence_label">문장 기록</string>
-    <string name="record_scan_sentence">문장 스캔하기</string>
-    <string name="record_next_button">다음</string>
-    <string name="record_page_hint">기록하고 싶은 페이지를 작성해보세요</string>
-    <string name="record_sentence_hint">기록하고 싶은 문장을 작성해보세요</string>
     <string name="record_exit_dialog_title">기록을 그만하고 나가시겠어요?</string>
     <string name="record_exit_dialog_description">지금까지 기록한 내용은 저장되지 않습니다.</string>
     <string name="record_exit_dialog_confirm">확인</string>
     <string name="record_exit_dialog_dismiss">취소</string>
+    <string name="record_next_button">다음</string>
+    <string name="quote_step_title">기록하고 싶은 페이지와\n문장을 등록해보세요</string>
+    <string name="quote_step_page_label">책 페이지</string>
+    <string name="quote_step_sentence_label">문장 기록</string>
+    <string name="quote_step_scan_sentence">문장 스캔하기</string>
+    <string name="quote_step_page_hint">기록하고 싶은 페이지를 작성해보세요</string>
+    <string name="quote_step_sentence_hint">기록하고 싶은 문장을 작성해보세요</string>
+    <string name="emotion_step_title">문장에 대해 어떤 감정이 드셨나요?</string>
+    <string name="emotion_step_description">대표 감정을 한 가지 선택해주세요</string>
+    <string name="impression_step_title">문장에 대한 감상을 남겨주세요</string>
+    <string name="impression_step_description">감상평 가이드로 쉽게 남길 수 있어요</string>
+    <string name="impression_step_hint">내용을 입력해주세요.</string>
 </resources>


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #67

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 감정 선택 화면 구현
- 감상문 입력 화면 및 감상평 가이드 구현

## 📸 스크린샷 또는 시연 영상
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

https://github.com/user-attachments/assets/f90b1e2f-68bc-4c9b-b561-687663285f25


## 💬 추가 설명 or 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 감정 선택 부분이 단순하게 개편되면서, 기록 플로우에 다루어야할 상태가 줄어들었습니다. 따라서 1개의 UI에 step 전환으로 진행해도 괜찮을 것 같아 그렇게 진행했습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 인용문, 감정, 감상을 단계별로 입력할 수 있는 다중 단계 기록 등록 UI를 도입했습니다.
  * 감정 선택, 감상 입력, 감상 가이드 하단 시트 및 가이드 선택 기능이 추가되었습니다.
  * 인용문, 감정, 감상 각 단계별 전용 입력 화면이 제공됩니다.
  * 감상 가이드 선택용 하단 시트 UI 컴포넌트가 새롭게 추가되었습니다.
  * 감상 가이드 박스 UI 컴포넌트가 도입되어 선택 상태를 시각화합니다.

* **버그 수정**
  * 진행 바가 현재 단계뿐 아니라 완료된 모든 단계를 강조 표시하도록 개선되었습니다.
  * 기록 목록 정렬 기본값이 보다 명확한 값으로 변경되었습니다.

* **문서화**
  * 새로운 단계별 입력 흐름에 맞는 문자열 리소스가 추가 및 정비되었습니다.

* **리팩터**
  * 기록 등록 UI와 상태 관리 구조가 다단계 흐름에 맞게 대대적으로 개편되었습니다.
  * 기록 등록 관련 컴포저블 함수들이 단계별 UI 구성으로 재구성되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->