### PR TITLE
feat: 약관 동의 API 연동 

### DIFF
--- a/core/data/api/src/main/kotlin/com/ninecraft/booket/core/data/api/repository/AuthRepository.kt
+++ b/core/data/api/src/main/kotlin/com/ninecraft/booket/core/data/api/repository/AuthRepository.kt
@@ -4,4 +4,6 @@ interface AuthRepository {
     suspend fun login(accessToken: String): Result<Unit>
 
     suspend fun logout(): Result<Unit>
+
+    suspend fun agreeTerms(termsAgreed: Boolean): Result<Unit>
 }

--- a/core/data/api/src/main/kotlin/com/ninecraft/booket/core/data/api/repository/UserRepository.kt
+++ b/core/data/api/src/main/kotlin/com/ninecraft/booket/core/data/api/repository/UserRepository.kt
@@ -1,12 +1,13 @@
 package com.ninecraft.booket.core.data.api.repository
 
+import com.ninecraft.booket.core.model.OnboardingState
 import com.ninecraft.booket.core.model.UserProfileModel
 import kotlinx.coroutines.flow.Flow
 
 interface UserRepository {
     suspend fun getUserProfile(): Result<UserProfileModel>
 
-    val isOnboardingCompleted: Flow<Boolean>
+    val onboardingState: Flow<OnboardingState>
 
     suspend fun setOnboardingCompleted(isCompleted: Boolean)
 }

--- a/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/mapper/ResponseToModel.kt
+++ b/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/mapper/ResponseToModel.kt
@@ -26,6 +26,7 @@ internal fun UserProfileResponse.toModel(): UserProfileModel {
         email = email,
         nickname = nickname,
         provider = provider,
+        termsAgreed = termsAgreed,
     )
 }
 

--- a/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/repository/DefaultAuthRepository.kt
+++ b/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/repository/DefaultAuthRepository.kt
@@ -4,6 +4,7 @@ import com.ninecraft.booket.core.common.utils.runSuspendCatching
 import com.ninecraft.booket.core.data.api.repository.AuthRepository
 import com.ninecraft.booket.core.datastore.api.datasource.TokenDataSource
 import com.ninecraft.booket.core.network.request.LoginRequest
+import com.ninecraft.booket.core.network.request.TermsAgreementRequest
 import com.ninecraft.booket.core.network.service.ReedService
 import javax.inject.Inject
 
@@ -26,6 +27,11 @@ internal class DefaultAuthRepository @Inject constructor(
     override suspend fun logout() = runSuspendCatching {
         service.logout()
         clearTokens()
+    }
+
+    override suspend fun agreeTerms(termsAgreed: Boolean) = runSuspendCatching {
+        service.agreeTerms(TermsAgreementRequest(termsAgreed))
+        Unit
     }
 
     private suspend fun saveTokens(accessToken: String, refreshToken: String) {

--- a/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/repository/DefaultUserRepository.kt
+++ b/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/repository/DefaultUserRepository.kt
@@ -15,7 +15,7 @@ internal class DefaultUserRepository @Inject constructor(
         service.getUserProfile().toModel()
     }
 
-    override val isOnboardingCompleted = onboardingDataSource.isOnboardingCompleted
+    override val onboardingState = onboardingDataSource.onboardingState
 
     override suspend fun setOnboardingCompleted(isCompleted: Boolean) {
         onboardingDataSource.setOnboardingCompleted(isCompleted)

--- a/core/datastore/api/build.gradle.kts
+++ b/core/datastore/api/build.gradle.kts
@@ -7,5 +7,9 @@ android {
 }
 
 dependencies {
-    implementation(libs.kotlinx.coroutines.core)
+    implementations(
+        projects.core.model,
+
+        libs.kotlinx.coroutines.core
+    )
 }

--- a/core/datastore/api/build.gradle.kts
+++ b/core/datastore/api/build.gradle.kts
@@ -10,6 +10,6 @@ dependencies {
     implementations(
         projects.core.model,
 
-        libs.kotlinx.coroutines.core
+        libs.kotlinx.coroutines.core,
     )
 }

--- a/core/datastore/api/src/main/kotlin/com/ninecraft/booket/core/datastore/api/datasource/OnboardingDataSource.kt
+++ b/core/datastore/api/src/main/kotlin/com/ninecraft/booket/core/datastore/api/datasource/OnboardingDataSource.kt
@@ -1,8 +1,9 @@
 package com.ninecraft.booket.core.datastore.api.datasource
 
+import com.ninecraft.booket.core.model.OnboardingState
 import kotlinx.coroutines.flow.Flow
 
 interface OnboardingDataSource {
-    val isOnboardingCompleted: Flow<Boolean>
+    val onboardingState: Flow<OnboardingState>
     suspend fun setOnboardingCompleted(isCompleted: Boolean)
 }

--- a/core/datastore/impl/build.gradle.kts
+++ b/core/datastore/impl/build.gradle.kts
@@ -17,6 +17,8 @@ android {
 dependencies {
     implementations(
         projects.core.datastore.api,
+        projects.core.model,
+
         libs.androidx.datastore.preferences,
 
         libs.logger,

--- a/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultOnboardingDataSource.kt
+++ b/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultOnboardingDataSource.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import com.ninecraft.booket.core.datastore.api.datasource.OnboardingDataSource
+import com.ninecraft.booket.core.model.OnboardingState
 import com.ninecraft.booket.core.datastore.impl.di.OnboardingDataStore
 import com.ninecraft.booket.core.datastore.impl.util.handleIOException
 import kotlinx.coroutines.flow.Flow
@@ -14,10 +15,13 @@ import javax.inject.Inject
 class DefaultOnboardingDataSource @Inject constructor(
     @OnboardingDataStore private val dataStore: DataStore<Preferences>,
 ) : OnboardingDataSource {
-    override val isOnboardingCompleted: Flow<Boolean> = dataStore.data
+    override val onboardingState: Flow<OnboardingState> = dataStore.data
         .handleIOException()
         .map { prefs ->
-            prefs[IS_ONBOARDING_COMPLETED] ?: false
+            when (prefs[IS_ONBOARDING_COMPLETED] ?: false) {
+                false -> OnboardingState.NotCompleted
+                true -> OnboardingState.Completed
+            }
         }
 
     override suspend fun setOnboardingCompleted(isCompleted: Boolean) {

--- a/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultOnboardingDataSource.kt
+++ b/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultOnboardingDataSource.kt
@@ -19,8 +19,8 @@ class DefaultOnboardingDataSource @Inject constructor(
         .handleIOException()
         .map { prefs ->
             when (prefs[IS_ONBOARDING_COMPLETED] ?: false) {
-                false -> OnboardingState.NotCompleted
-                true -> OnboardingState.Completed
+                false -> OnboardingState.NOT_COMPLETED
+                true -> OnboardingState.COMPLETED
             }
         }
 

--- a/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/button/ReedButton.kt
+++ b/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/button/ReedButton.kt
@@ -148,15 +148,15 @@ private fun ReedLargeButtonPreview() {
         ) {
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.PRIMARY,
                 sizeStyle = largeRoundedButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.SECONDARY,
                 sizeStyle = largeRoundedButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
@@ -166,9 +166,9 @@ private fun ReedLargeButtonPreview() {
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.STROKE,
                 sizeStyle = largeRoundedButtonStyle,
-                text = "button",
             )
         }
         FlowRow(
@@ -180,9 +180,9 @@ private fun ReedLargeButtonPreview() {
             ) {
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.PRIMARY,
                     sizeStyle = largeButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -198,9 +198,9 @@ private fun ReedLargeButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.SECONDARY,
                     sizeStyle = largeButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -216,9 +216,9 @@ private fun ReedLargeButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.TERTIARY,
                     sizeStyle = largeButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -234,9 +234,9 @@ private fun ReedLargeButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.STROKE,
                     sizeStyle = largeButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -256,9 +256,9 @@ private fun ReedLargeButtonPreview() {
             ) {
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.PRIMARY,
                     sizeStyle = largeRoundedButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -274,9 +274,9 @@ private fun ReedLargeButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.SECONDARY,
                     sizeStyle = largeRoundedButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -292,9 +292,9 @@ private fun ReedLargeButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.TERTIARY,
                     sizeStyle = largeRoundedButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -310,9 +310,9 @@ private fun ReedLargeButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.STROKE,
                     sizeStyle = largeRoundedButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -344,27 +344,27 @@ private fun ReedMediumButtonPreview() {
         ) {
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.PRIMARY,
                 sizeStyle = mediumButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.SECONDARY,
                 sizeStyle = mediumButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.TERTIARY,
                 sizeStyle = mediumButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.STROKE,
                 sizeStyle = mediumButtonStyle,
-                text = "button",
             )
         }
         FlowRow(
@@ -373,27 +373,27 @@ private fun ReedMediumButtonPreview() {
         ) {
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.PRIMARY,
                 sizeStyle = mediumRoundedButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.SECONDARY,
                 sizeStyle = mediumRoundedButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.TERTIARY,
                 sizeStyle = mediumRoundedButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.STROKE,
                 sizeStyle = mediumRoundedButtonStyle,
-                text = "button",
             )
         }
         FlowRow(
@@ -404,9 +404,9 @@ private fun ReedMediumButtonPreview() {
             ) {
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.PRIMARY,
                     sizeStyle = mediumButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -422,9 +422,9 @@ private fun ReedMediumButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.SECONDARY,
                     sizeStyle = mediumButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -440,9 +440,9 @@ private fun ReedMediumButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.TERTIARY,
                     sizeStyle = mediumButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -458,9 +458,9 @@ private fun ReedMediumButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.STROKE,
                     sizeStyle = mediumButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -480,9 +480,9 @@ private fun ReedMediumButtonPreview() {
             ) {
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.PRIMARY,
                     sizeStyle = mediumRoundedButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -498,9 +498,9 @@ private fun ReedMediumButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.SECONDARY,
                     sizeStyle = mediumRoundedButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -516,9 +516,9 @@ private fun ReedMediumButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.TERTIARY,
                     sizeStyle = mediumRoundedButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -534,9 +534,9 @@ private fun ReedMediumButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.STROKE,
                     sizeStyle = mediumRoundedButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -568,27 +568,27 @@ private fun ReedSmallButtonPreview() {
         ) {
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.PRIMARY,
                 sizeStyle = smallButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.SECONDARY,
                 sizeStyle = smallButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.TERTIARY,
                 sizeStyle = smallButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.STROKE,
                 sizeStyle = smallButtonStyle,
-                text = "button",
             )
         }
         Row(
@@ -596,27 +596,27 @@ private fun ReedSmallButtonPreview() {
         ) {
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.PRIMARY,
                 sizeStyle = smallRoundedButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.SECONDARY,
                 sizeStyle = smallRoundedButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.TERTIARY,
                 sizeStyle = smallRoundedButtonStyle,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.STROKE,
                 sizeStyle = smallRoundedButtonStyle,
-                text = "button",
             )
         }
         Row(
@@ -627,9 +627,9 @@ private fun ReedSmallButtonPreview() {
             ) {
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.PRIMARY,
                     sizeStyle = smallButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -645,9 +645,9 @@ private fun ReedSmallButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.SECONDARY,
                     sizeStyle = smallButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -663,9 +663,9 @@ private fun ReedSmallButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.TERTIARY,
                     sizeStyle = smallButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -681,9 +681,9 @@ private fun ReedSmallButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.STROKE,
                     sizeStyle = smallButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -703,9 +703,9 @@ private fun ReedSmallButtonPreview() {
             ) {
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.PRIMARY,
                     sizeStyle = smallRoundedButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -721,9 +721,9 @@ private fun ReedSmallButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.SECONDARY,
                     sizeStyle = smallRoundedButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -739,9 +739,9 @@ private fun ReedSmallButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.TERTIARY,
                     sizeStyle = smallRoundedButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -757,9 +757,9 @@ private fun ReedSmallButtonPreview() {
                 )
                 ReedButton(
                     onClick = {},
+                    text = "button",
                     colorStyle = ReedButtonColorStyle.STROKE,
                     sizeStyle = smallRoundedButtonStyle,
-                    text = "button",
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Check,
@@ -791,23 +791,23 @@ private fun ReedButtonDisabledPreview() {
         ) {
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.PRIMARY,
                 sizeStyle = largeButtonStyle,
                 enabled = false,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.PRIMARY,
                 sizeStyle = largeRoundedButtonStyle,
                 enabled = false,
-                text = "button",
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.PRIMARY,
                 sizeStyle = largeButtonStyle,
-                text = "button",
                 enabled = false,
                 leadingIcon = {
                     Icon(
@@ -824,10 +824,10 @@ private fun ReedButtonDisabledPreview() {
             )
             ReedButton(
                 onClick = {},
+                text = "button",
                 colorStyle = ReedButtonColorStyle.PRIMARY,
                 sizeStyle = largeRoundedButtonStyle,
                 enabled = false,
-                text = "button",
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.Default.Check,

--- a/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/button/ReedButton.kt
+++ b/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/button/ReedButton.kt
@@ -33,13 +33,14 @@ import com.ninecraft.booket.core.designsystem.ComponentPreview
 @Composable
 fun ReedButton(
     onClick: () -> Unit,
+    text: String,
     sizeStyle: ButtonSizeStyle,
     colorStyle: ReedButtonColorStyle,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    text: String = "",
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
+    multipleEventsCutterEnabled: Boolean = true,
 ) {
     val multipleEventsCutter = remember { MultipleEventsCutter.get() }
 
@@ -53,7 +54,13 @@ fun ReedButton(
     )
 
     Button(
-        onClick = { multipleEventsCutter.processEvent { onClick() } },
+        onClick = {
+            if (multipleEventsCutterEnabled) {
+                multipleEventsCutter.processEvent { onClick() }
+            } else {
+                onClick()
+            }
+        },
         modifier = modifier.graphicsLayer {
             scaleX = scale
             scaleY = scale

--- a/core/model/src/main/kotlin/com/ninecraft/booket/core/model/OnboardingState.kt
+++ b/core/model/src/main/kotlin/com/ninecraft/booket/core/model/OnboardingState.kt
@@ -3,5 +3,5 @@ package com.ninecraft.booket.core.model
 enum class OnboardingState {
     Idle,
     NotCompleted,
-    Completed
+    Completed,
 }

--- a/core/model/src/main/kotlin/com/ninecraft/booket/core/model/OnboardingState.kt
+++ b/core/model/src/main/kotlin/com/ninecraft/booket/core/model/OnboardingState.kt
@@ -1,7 +1,7 @@
 package com.ninecraft.booket.core.model
 
 enum class OnboardingState {
-    Idle,
-    NotCompleted,
-    Completed,
+    IDLE,
+    NOT_COMPLETED,
+    COMPLETED,
 }

--- a/core/model/src/main/kotlin/com/ninecraft/booket/core/model/OnboardingState.kt
+++ b/core/model/src/main/kotlin/com/ninecraft/booket/core/model/OnboardingState.kt
@@ -1,0 +1,7 @@
+package com.ninecraft.booket.core.model
+
+enum class OnboardingState {
+    Idle,
+    NotCompleted,
+    Completed
+}

--- a/core/model/src/main/kotlin/com/ninecraft/booket/core/model/UserProfileModel.kt
+++ b/core/model/src/main/kotlin/com/ninecraft/booket/core/model/UserProfileModel.kt
@@ -8,4 +8,5 @@ data class UserProfileModel(
     val email: String,
     val nickname: String,
     val provider: String,
+    val termsAgreed: Boolean,
 )

--- a/core/network/src/main/kotlin/com/ninecraft/booket/core/network/request/TermsAgreementRequest.kt
+++ b/core/network/src/main/kotlin/com/ninecraft/booket/core/network/request/TermsAgreementRequest.kt
@@ -1,0 +1,10 @@
+package com.ninecraft.booket.core.network.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TermsAgreementRequest(
+    @SerialName("termsAgreed")
+    val termsAgreed: Boolean
+)

--- a/core/network/src/main/kotlin/com/ninecraft/booket/core/network/request/TermsAgreementRequest.kt
+++ b/core/network/src/main/kotlin/com/ninecraft/booket/core/network/request/TermsAgreementRequest.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class TermsAgreementRequest(
     @SerialName("termsAgreed")
-    val termsAgreed: Boolean
+    val termsAgreed: Boolean,
 )

--- a/core/network/src/main/kotlin/com/ninecraft/booket/core/network/response/TermsAgreementResponse.kt
+++ b/core/network/src/main/kotlin/com/ninecraft/booket/core/network/response/TermsAgreementResponse.kt
@@ -1,0 +1,18 @@
+package com.ninecraft.booket.core.network.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TermsAgreementResponse(
+    @SerialName("id")
+    val id: String,
+    @SerialName("email")
+    val email: String,
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("provider")
+    val provider: String,
+    @SerialName("termsAgreed")
+    val termsAgreed: Boolean,
+)

--- a/core/network/src/main/kotlin/com/ninecraft/booket/core/network/response/UserProfileResponse.kt
+++ b/core/network/src/main/kotlin/com/ninecraft/booket/core/network/response/UserProfileResponse.kt
@@ -13,4 +13,6 @@ data class UserProfileResponse(
     val nickname: String,
     @SerialName("provider")
     val provider: String,
+    @SerialName("termsAgreed")
+    val termsAgreed: Boolean,
 )

--- a/core/network/src/main/kotlin/com/ninecraft/booket/core/network/service/ReedService.kt
+++ b/core/network/src/main/kotlin/com/ninecraft/booket/core/network/service/ReedService.kt
@@ -3,12 +3,14 @@ package com.ninecraft.booket.core.network.service
 import com.ninecraft.booket.core.network.request.BookUpsertRequest
 import com.ninecraft.booket.core.network.request.LoginRequest
 import com.ninecraft.booket.core.network.request.RefreshTokenRequest
+import com.ninecraft.booket.core.network.request.TermsAgreementRequest
 import com.ninecraft.booket.core.network.response.BookDetailResponse
 import com.ninecraft.booket.core.network.response.BookSearchResponse
 import com.ninecraft.booket.core.network.response.BookUpsertResponse
 import com.ninecraft.booket.core.network.response.LibraryResponse
 import com.ninecraft.booket.core.network.response.LoginResponse
 import com.ninecraft.booket.core.network.response.RefreshTokenResponse
+import com.ninecraft.booket.core.network.response.TermsAgreementResponse
 import com.ninecraft.booket.core.network.response.UserProfileResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -27,6 +29,9 @@ interface ReedService {
     // Auth endpoints (auth required)
     @POST("api/v1/auth/signout")
     suspend fun logout()
+
+    @PUT("api/v1/auth/terms-agreement")
+    suspend fun agreeTerms(@Body termsAgreementRequest: TermsAgreementRequest): TermsAgreementResponse
 
     @GET("api/v1/auth/me")
     suspend fun getUserProfile(): UserProfileResponse

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/login/LoginPresenter.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/login/LoginPresenter.kt
@@ -5,12 +5,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import com.slack.circuit.retained.collectAsRetainedState
 import com.ninecraft.booket.core.data.api.repository.AuthRepository
 import com.ninecraft.booket.core.data.api.repository.UserRepository
 import com.ninecraft.booket.feature.screens.BottomNavigationScreen
 import com.ninecraft.booket.feature.screens.LoginScreen
-import com.ninecraft.booket.feature.screens.OnboardingScreen
 import com.ninecraft.booket.feature.screens.TermsAgreementScreen
 import com.orhanobut.logger.Logger
 import com.slack.circuit.codegen.annotations.CircuitInject
@@ -34,18 +32,13 @@ class LoginPresenter @AssistedInject constructor(
         val scope = rememberCoroutineScope()
         var isLoading by rememberRetained { mutableStateOf(false) }
         var sideEffect by rememberRetained { mutableStateOf<LoginSideEffect?>(null) }
-        val isOnboardingCompleted by userRepository.isOnboardingCompleted.collectAsRetainedState(initial = false)
 
         fun navigateAfterLogin() {
             scope.launch {
                 userRepository.getUserProfile()
                     .onSuccess { userProfile ->
                         if (userProfile.termsAgreed) {
-                            if (isOnboardingCompleted) {
-                                navigator.resetRoot(BottomNavigationScreen)
-                            } else {
-                                navigator.resetRoot(OnboardingScreen)
-                            }
+                            navigator.resetRoot(BottomNavigationScreen)
                         } else {
                             navigator.resetRoot(TermsAgreementScreen)
                         }

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/login/LoginPresenter.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/login/LoginPresenter.kt
@@ -34,9 +34,7 @@ class LoginPresenter @AssistedInject constructor(
         val scope = rememberCoroutineScope()
         var isLoading by rememberRetained { mutableStateOf(false) }
         var sideEffect by rememberRetained { mutableStateOf<LoginSideEffect?>(null) }
-        val isOnboardingCompleted by userRepository.isOnboardingCompleted.collectAsRetainedState(
-            initial = false
-        )
+        val isOnboardingCompleted by userRepository.isOnboardingCompleted.collectAsRetainedState(initial = false)
 
         fun navigateAfterLogin() {
             scope.launch {

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/HandleTermsAgreementSideEffects.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/HandleTermsAgreementSideEffects.kt
@@ -1,0 +1,28 @@
+package com.ninecraft.booket.feature.termsagreement
+
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import com.ninecraft.booket.feature.login.KakaoLoginClient
+import com.ninecraft.booket.feature.login.LoginSideEffect
+import com.ninecraft.booket.feature.login.LoginUiEvent
+import com.ninecraft.booket.feature.login.LoginUiState
+import com.skydoves.compose.effects.RememberedEffect
+
+@Composable
+internal fun HandleTermsAgreementSideEffects(
+    state: TermsAgreementUiState,
+) {
+    val context = LocalContext.current
+
+    RememberedEffect(state.sideEffect) {
+        when (state.sideEffect) {
+            is TermsAgreementSideEffect.ShowToast -> {
+                Toast.makeText(context, state.sideEffect.message, Toast.LENGTH_SHORT).show()
+            }
+
+            null -> {}
+        }
+    }
+}

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/HandleTermsAgreementSideEffects.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/HandleTermsAgreementSideEffects.kt
@@ -2,12 +2,7 @@ package com.ninecraft.booket.feature.termsagreement
 
 import android.widget.Toast
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
-import com.ninecraft.booket.feature.login.KakaoLoginClient
-import com.ninecraft.booket.feature.login.LoginSideEffect
-import com.ninecraft.booket.feature.login.LoginUiEvent
-import com.ninecraft.booket.feature.login.LoginUiState
 import com.skydoves.compose.effects.RememberedEffect
 
 @Composable

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/TermsAgreementPresenter.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/TermsAgreementPresenter.kt
@@ -9,14 +9,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import com.ninecraft.booket.core.common.constants.WebViewConstants
 import com.ninecraft.booket.core.data.api.repository.AuthRepository
-import com.ninecraft.booket.core.data.api.repository.UserRepository
 import com.ninecraft.booket.feature.screens.BottomNavigationScreen
-import com.ninecraft.booket.feature.screens.OnboardingScreen
 import com.ninecraft.booket.feature.screens.TermsAgreementScreen
 import com.ninecraft.booket.feature.screens.WebViewScreen
 import com.orhanobut.logger.Logger
 import com.slack.circuit.codegen.annotations.CircuitInject
-import com.slack.circuit.retained.collectAsRetainedState
 import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
@@ -30,7 +27,6 @@ import kotlinx.coroutines.launch
 
 class TermsAgreementPresenter @AssistedInject constructor(
     @Assisted private val navigator: Navigator,
-    private val userRepository: UserRepository,
     private val authRepository: AuthRepository,
 ) : Presenter<TermsAgreementUiState> {
 
@@ -48,8 +44,6 @@ class TermsAgreementPresenter @AssistedInject constructor(
                 agreedTerms.all { it }
             }
         }
-
-        val isOnboardingCompleted by userRepository.isOnboardingCompleted.collectAsRetainedState(initial = false)
 
         fun handleEvent(event: TermsAgreementUiEvent) {
             when (event) {
@@ -76,11 +70,7 @@ class TermsAgreementPresenter @AssistedInject constructor(
                     scope.launch {
                         authRepository.agreeTerms(true)
                             .onSuccess {
-                                if (isOnboardingCompleted) {
-                                    navigator.resetRoot(BottomNavigationScreen)
-                                } else {
-                                    navigator.resetRoot(OnboardingScreen)
-                                }
+                                navigator.resetRoot(BottomNavigationScreen)
                             }.onFailure { exception ->
                                 exception.message?.let { Logger.e(it) }
                                 sideEffect = exception.message?.let {

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/TermsAgreementPresenter.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/TermsAgreementPresenter.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.setValue
 import com.ninecraft.booket.core.common.constants.WebViewConstants
 import com.ninecraft.booket.core.data.api.repository.AuthRepository
 import com.ninecraft.booket.core.data.api.repository.UserRepository
-import com.ninecraft.booket.feature.login.LoginSideEffect
 import com.ninecraft.booket.feature.screens.BottomNavigationScreen
 import com.ninecraft.booket.feature.screens.OnboardingScreen
 import com.ninecraft.booket.feature.screens.TermsAgreementScreen
@@ -27,7 +26,6 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.components.ActivityRetainedComponent
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
 class TermsAgreementPresenter @AssistedInject constructor(

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/TermsAgreementUi.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/TermsAgreementUi.kt
@@ -12,16 +12,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import com.ninecraft.booket.core.common.extensions.noRippleClickable
 import com.ninecraft.booket.core.designsystem.DevicePreview
@@ -29,15 +25,14 @@ import com.ninecraft.booket.core.designsystem.component.button.ReedButton
 import com.ninecraft.booket.core.designsystem.component.button.ReedButtonColorStyle
 import com.ninecraft.booket.core.designsystem.component.button.largeButtonStyle
 import com.ninecraft.booket.core.designsystem.component.checkbox.SquareCheckBox
-import com.ninecraft.booket.core.designsystem.component.checkbox.TickOnlyCheckBox
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
 import com.ninecraft.booket.core.designsystem.theme.White
 import com.ninecraft.booket.feature.login.R
 import com.ninecraft.booket.feature.screens.TermsAgreementScreen
+import com.ninecraft.booket.feature.termsagreement.component.TermItem
 import com.slack.circuit.codegen.annotations.CircuitInject
 import dagger.hilt.android.components.ActivityRetainedComponent
 import kotlinx.collections.immutable.persistentListOf
-import com.ninecraft.booket.core.designsystem.R as designR
 
 @CircuitInject(TermsAgreementScreen::class, ActivityRetainedComponent::class)
 @Composable
@@ -45,6 +40,8 @@ internal fun TermsAgreementUi(
     state: TermsAgreementUiState,
     modifier: Modifier = Modifier,
 ) {
+    HandleTermsAgreementSideEffects(state = state)
+
     val termsTitles = stringArrayResource(id = R.array.terms_agreement_items)
 
     Column(
@@ -53,8 +50,7 @@ internal fun TermsAgreementUi(
             .background(White)
             .systemBarsPadding(),
     ) {
-        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing16))
-        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing3))
+        Spacer(modifier = Modifier.height(76.dp))
         Column(
             modifier = Modifier
                 .weight(1f)
@@ -144,49 +140,6 @@ internal fun TermsAgreementUi(
             enabled = state.isAllAgreed,
             text = stringResource(R.string.terms_agreement_button_start),
         )
-    }
-}
-
-@Composable
-private fun TermItem(
-    title: String,
-    onCheckClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    checked: Boolean = false,
-    hasDetailAction: Boolean = true,
-    onDetailClick: () -> Unit = {},
-) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .noRippleClickable { onDetailClick() }
-            .padding(
-                start = ReedTheme.spacing.spacing4 + ReedTheme.spacing.spacing05,
-                end = ReedTheme.spacing.spacing3,
-                top = ReedTheme.spacing.spacing2,
-                bottom = ReedTheme.spacing.spacing2,
-            ),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        TickOnlyCheckBox(
-            checked = checked,
-            onCheckedChange = { onCheckClick() },
-        )
-        Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing3 + ReedTheme.spacing.spacing05))
-        Text(
-            text = title,
-            modifier = Modifier.weight(1f),
-            color = ReedTheme.colors.contentPrimary,
-            style = ReedTheme.typography.body1Medium,
-        )
-
-        if (hasDetailAction) {
-            Icon(
-                imageVector = ImageVector.vectorResource(id = designR.drawable.ic_chevron_right),
-                contentDescription = "Navigation Icon",
-                tint = Color.Unspecified,
-            )
-        }
     }
 }
 

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/TermsAgreementUiState.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/TermsAgreementUiState.kt
@@ -1,14 +1,24 @@
 package com.ninecraft.booket.feature.termsagreement
 
+import com.ninecraft.booket.feature.login.LoginSideEffect
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import kotlinx.collections.immutable.ImmutableList
+import java.util.UUID
 
 data class TermsAgreementUiState(
     val isAllAgreed: Boolean,
     val agreedTerms: ImmutableList<Boolean>,
+    val sideEffect: TermsAgreementSideEffect? = null,
     val eventSink: (TermsAgreementUiEvent) -> Unit,
 ) : CircuitUiState
+
+sealed interface TermsAgreementSideEffect {
+    data class ShowToast(
+        val message: String,
+        private val key: String = UUID.randomUUID().toString(),
+    ) : TermsAgreementSideEffect
+}
 
 sealed interface TermsAgreementUiEvent : CircuitUiEvent {
     data object OnAllTermsAgreedClick : TermsAgreementUiEvent

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/TermsAgreementUiState.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/TermsAgreementUiState.kt
@@ -1,6 +1,5 @@
 package com.ninecraft.booket.feature.termsagreement
 
-import com.ninecraft.booket.feature.login.LoginSideEffect
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import kotlinx.collections.immutable.ImmutableList

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/component/TermsItem.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/component/TermsItem.kt
@@ -1,0 +1,74 @@
+package com.ninecraft.booket.feature.termsagreement.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import com.ninecraft.booket.core.common.extensions.noRippleClickable
+import com.ninecraft.booket.core.designsystem.ComponentPreview
+import com.ninecraft.booket.core.designsystem.component.checkbox.TickOnlyCheckBox
+import com.ninecraft.booket.core.designsystem.theme.ReedTheme
+import com.ninecraft.booket.core.designsystem.R as designR
+
+@Composable
+internal fun TermItem(
+    title: String,
+    onCheckClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    checked: Boolean = false,
+    hasDetailAction: Boolean = true,
+    onDetailClick: () -> Unit = {},
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .noRippleClickable { onDetailClick() }
+            .padding(
+                start = ReedTheme.spacing.spacing4 + ReedTheme.spacing.spacing05,
+                end = ReedTheme.spacing.spacing3,
+                top = ReedTheme.spacing.spacing2,
+                bottom = ReedTheme.spacing.spacing2,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        TickOnlyCheckBox(
+            checked = checked,
+            onCheckedChange = { onCheckClick() },
+        )
+        Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing3 + ReedTheme.spacing.spacing05))
+        Text(
+            text = title,
+            modifier = Modifier.weight(1f),
+            color = ReedTheme.colors.contentPrimary,
+            style = ReedTheme.typography.body1Medium,
+        )
+
+        if (hasDetailAction) {
+            Icon(
+                imageVector = ImageVector.vectorResource(id = designR.drawable.ic_chevron_right),
+                contentDescription = "Navigation Icon",
+                tint = Color.Unspecified,
+            )
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun TermItemPreview() {
+    ReedTheme {
+        TermItem(
+            title = "(필수)서비스 이용약관",
+            onCheckClick = {}
+        )
+    }
+}

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/component/TermsItem.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/termsagreement/component/TermsItem.kt
@@ -68,7 +68,7 @@ private fun TermItemPreview() {
     ReedTheme {
         TermItem(
             title = "(필수)서비스 이용약관",
-            onCheckClick = {}
+            onCheckClick = {},
         )
     }
 }

--- a/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/MainActivity.kt
+++ b/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/MainActivity.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
 import com.ninecraft.booket.core.designsystem.theme.White
-import com.ninecraft.booket.feature.screens.LoginScreen
+import com.ninecraft.booket.feature.screens.SplashScreen
 import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
@@ -46,7 +46,7 @@ class MainActivity : ComponentActivity() {
             }
 
             ReedTheme {
-                val backStack = rememberSaveableBackStack(root = LoginScreen)
+                val backStack = rememberSaveableBackStack(root = SplashScreen)
                 val navigator = rememberCircuitNavigator(backStack)
 
                 CircuitCompositionLocals(circuit) {

--- a/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashPresenter.kt
+++ b/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashPresenter.kt
@@ -1,0 +1,59 @@
+package com.ninecraft.booket.feature.main.splash
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import com.ninecraft.booket.core.data.api.repository.UserRepository
+import com.ninecraft.booket.core.model.OnboardingState
+import com.ninecraft.booket.feature.screens.LoginScreen
+import com.ninecraft.booket.feature.screens.OnboardingScreen
+import com.ninecraft.booket.feature.screens.SplashScreen
+import com.skydoves.compose.effects.RememberedEffect
+import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.retained.collectAsRetainedState
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.components.ActivityRetainedComponent
+
+class SplashPresenter @AssistedInject constructor(
+    @Assisted private val navigator: Navigator,
+    private val userRepository: UserRepository,
+) : Presenter<SplashUiState> {
+
+    @Composable
+    override fun present(): SplashUiState {
+        val onboardingState by userRepository.onboardingState.collectAsRetainedState(initial = OnboardingState.Idle)
+
+        LaunchedEffect(onboardingState) {
+            when (onboardingState) {
+                OnboardingState.Idle -> {
+                    // 초기 진입 상태
+                }
+                OnboardingState.NotCompleted -> {
+                    navigator.resetRoot(OnboardingScreen)
+                }
+                OnboardingState.Completed -> {
+                    navigator.resetRoot(LoginScreen)
+                }
+            }
+        }
+
+        return SplashUiState(
+            idle = onboardingState == OnboardingState.Idle,
+            isOnboardingCompleted = when (onboardingState) {
+                OnboardingState.Idle -> null
+                OnboardingState.NotCompleted -> false
+                OnboardingState.Completed -> true
+            }
+        )
+    }
+
+    @CircuitInject(SplashScreen::class, ActivityRetainedComponent::class)
+    @AssistedFactory
+    fun interface Factory {
+        fun create(navigator: Navigator): SplashPresenter
+    }
+}

--- a/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashPresenter.kt
+++ b/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashPresenter.kt
@@ -1,7 +1,6 @@
 package com.ninecraft.booket.feature.main.splash
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import com.ninecraft.booket.core.data.api.repository.UserRepository
 import com.ninecraft.booket.core.model.OnboardingState
@@ -27,14 +26,16 @@ class SplashPresenter @AssistedInject constructor(
     override fun present(): SplashUiState {
         val onboardingState by userRepository.onboardingState.collectAsRetainedState(initial = OnboardingState.Idle)
 
-        LaunchedEffect(onboardingState) {
+        RememberedEffect(onboardingState) {
             when (onboardingState) {
                 OnboardingState.Idle -> {
                     // 초기 진입 상태
                 }
+
                 OnboardingState.NotCompleted -> {
                     navigator.resetRoot(OnboardingScreen)
                 }
+
                 OnboardingState.Completed -> {
                     navigator.resetRoot(LoginScreen)
                 }
@@ -47,7 +48,7 @@ class SplashPresenter @AssistedInject constructor(
                 OnboardingState.Idle -> null
                 OnboardingState.NotCompleted -> false
                 OnboardingState.Completed -> true
-            }
+            },
         )
     }
 

--- a/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashPresenter.kt
+++ b/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashPresenter.kt
@@ -24,30 +24,30 @@ class SplashPresenter @AssistedInject constructor(
 
     @Composable
     override fun present(): SplashUiState {
-        val onboardingState by userRepository.onboardingState.collectAsRetainedState(initial = OnboardingState.Idle)
+        val onboardingState by userRepository.onboardingState.collectAsRetainedState(initial = OnboardingState.IDLE)
 
         RememberedEffect(onboardingState) {
             when (onboardingState) {
-                OnboardingState.Idle -> {
+                OnboardingState.IDLE -> {
                     // 초기 진입 상태
                 }
 
-                OnboardingState.NotCompleted -> {
+                OnboardingState.NOT_COMPLETED -> {
                     navigator.resetRoot(OnboardingScreen)
                 }
 
-                OnboardingState.Completed -> {
+                OnboardingState.COMPLETED -> {
                     navigator.resetRoot(LoginScreen)
                 }
             }
         }
 
         return SplashUiState(
-            idle = onboardingState == OnboardingState.Idle,
+            idle = onboardingState == OnboardingState.IDLE,
             isOnboardingCompleted = when (onboardingState) {
-                OnboardingState.Idle -> null
-                OnboardingState.NotCompleted -> false
-                OnboardingState.Completed -> true
+                OnboardingState.IDLE -> null
+                OnboardingState.NOT_COMPLETED -> false
+                OnboardingState.COMPLETED -> true
             },
         )
     }

--- a/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashUi.kt
+++ b/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashUi.kt
@@ -11,7 +11,6 @@ import dagger.hilt.android.components.ActivityRetainedComponent
 @CircuitInject(SplashScreen::class, ActivityRetainedComponent::class)
 @Composable
 fun SplashUi(
-    state: SplashUiState,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize())

--- a/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashUi.kt
+++ b/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashUi.kt
@@ -1,0 +1,18 @@
+package com.ninecraft.booket.feature.main.splash
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.ninecraft.booket.feature.screens.SplashScreen
+import com.slack.circuit.codegen.annotations.CircuitInject
+import dagger.hilt.android.components.ActivityRetainedComponent
+
+@CircuitInject(SplashScreen::class, ActivityRetainedComponent::class)
+@Composable
+fun SplashUi(
+    state: SplashUiState,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize())
+}

--- a/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashUiState.kt
+++ b/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashUiState.kt
@@ -4,5 +4,5 @@ import com.slack.circuit.runtime.CircuitUiState
 
 data class SplashUiState(
     val idle: Boolean = true,
-    val isOnboardingCompleted: Boolean? = null
+    val isOnboardingCompleted: Boolean? = null,
 ) : CircuitUiState

--- a/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashUiState.kt
+++ b/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/splash/SplashUiState.kt
@@ -1,0 +1,8 @@
+package com.ninecraft.booket.feature.main.splash
+
+import com.slack.circuit.runtime.CircuitUiState
+
+data class SplashUiState(
+    val idle: Boolean = true,
+    val isOnboardingCompleted: Boolean? = null
+) : CircuitUiState

--- a/feature/onboarding/src/main/kotlin/com/ninecraft/booket/feature/onboarding/OnboardingPresenter.kt
+++ b/feature/onboarding/src/main/kotlin/com/ninecraft/booket/feature/onboarding/OnboardingPresenter.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import com.ninecraft.booket.core.data.api.repository.UserRepository
-import com.ninecraft.booket.feature.screens.BottomNavigationScreen
+import com.ninecraft.booket.feature.screens.LoginScreen
 import com.ninecraft.booket.feature.screens.OnboardingScreen
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
@@ -34,7 +34,7 @@ class OnboardingPresenter @AssistedInject constructor(
                     if (event.currentPage == 2) {
                         scope.launch {
                             repository.setOnboardingCompleted(true)
-                            navigator.resetRoot(BottomNavigationScreen)
+                            navigator.resetRoot(LoginScreen)
                         }
                     } else {
                         pagerState.let { state ->

--- a/feature/onboarding/src/main/kotlin/com/ninecraft/booket/feature/onboarding/OnboardingUi.kt
+++ b/feature/onboarding/src/main/kotlin/com/ninecraft/booket/feature/onboarding/OnboardingUi.kt
@@ -87,6 +87,7 @@ internal fun OnboardingUi(
                     .padding(
                         horizontal = ReedTheme.spacing.spacing5,
                     ),
+                multipleEventsCutterEnabled = false,
             )
             Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing4))
         }

--- a/feature/onboarding/src/main/kotlin/com/ninecraft/booket/feature/onboarding/component/PagerIndicator.kt
+++ b/feature/onboarding/src/main/kotlin/com/ninecraft/booket/feature/onboarding/component/PagerIndicator.kt
@@ -38,7 +38,7 @@ internal fun PagerIndicator(
 
                 Box(
                     modifier = Modifier
-                        .padding(horizontal = 8.dp)
+                        .padding(horizontal = 4.dp)
                         .clip(CircleShape)
                         .background(color)
                         .size(8.dp),

--- a/feature/screens/src/main/kotlin/com/ninecraft/booket/feature/screens/Screens.kt
+++ b/feature/screens/src/main/kotlin/com/ninecraft/booket/feature/screens/Screens.kt
@@ -52,3 +52,6 @@ data class BookDetailScreen(val isbn: String) : ReedScreen(name = "BookDetail()"
 
 @Parcelize
 data object OnboardingScreen : ReedScreen(name = "Onboarding()")
+
+@Parcelize
+data object SplashScreen : ReedScreen(name = "Splash()")


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close https://github.com/YAPP-Github/Reed-Android/issues/79

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 약관 동의 여부 API 연동
- 약관 동의 완료시, 로그인 이후 약관 동의 화면으로 이동되지 않도록(getUserProfile API를 통해 약관 동의 여부 체크)
- 겸사 겸사 로그인 화면에서 온보딩 완료 여부 체크 추가
- 온보딩 화면 위치 변경(로그인 화면 보다 앞쪽으로, 기획이 그럼)
- ReedButton multiEventCutter 토글 적용(버튼 빠르게 클릭시 클릭이 씹히는 문제 해결)

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 정상 동작되는지 확인 부탁드림다
- 약관 동의 API의 경우 respons로 여러 데이터들이 담겨오는데, 딱히 앱에서 사용하는 데이터는 없어서 Presenter로 올릴때 Result<Unit>만 반환되도록 구현했슴다(성공/실패 여부만 필요)
- 그러고 보니 자동 로그인도 구현해야되네여 
- SplashScreen의 및 OnboardingState 도입 이유는 [61d6274](https://github.com/YAPP-Github/Reed-Android/pull/80/commits/61d6274cf3697beef58686b337e7ee0210cc390d) 해당 커밋 description 참고 부탁드림다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이용약관 동의 상태(termsAgreed) 관리 기능이 추가되었습니다.
  * 스플래시 화면이 도입되어 앱 시작 시 온보딩 완료 여부에 따라 자동으로 화면이 전환됩니다.
  * 온보딩 상태를 Idle, NotCompleted, Completed로 구분하여 보다 정교하게 관리합니다.
  * 약관 동의 화면에 새로운 UI 컴포넌트와 토스트 메시지 처리 기능이 추가되었습니다.

* **UI 개선**
  * 로그인 및 약관 동의 화면의 네비게이션 흐름이 약관 동의 여부에 따라 달라집니다.
  * 약관 동의 UI 및 토스트 메시지 등 사용자 피드백이 강화되었습니다.
  * 온보딩 인디케이터의 패딩이 조정되어 디자인이 개선되었습니다.
  * 약관 동의 UI 컴포넌트가 외부 모듈로 분리되어 유지보수성이 향상되었습니다.

* **버그 수정**
  * 약관 동의 처리 및 상태 반영 과정에서 발생할 수 있는 오류 메시지가 토스트로 안내됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->