### PR TITLE
feat: 독서 기록 플로우 화면 - 입력 유효성 처리 및 세부 UX 개선

### DIFF
--- a/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/button/ButtonColorStyle.kt
+++ b/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/button/ButtonColorStyle.kt
@@ -7,11 +7,12 @@ import com.ninecraft.booket.core.designsystem.theme.Kakao
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
 
 enum class ReedButtonColorStyle {
-    PRIMARY, SECONDARY, TERTIARY, STROKE, KAKAO;
+    PRIMARY, PRIMARY_INVERSE_TEXT, SECONDARY, TERTIARY, STROKE, KAKAO;
 
     @Composable
     fun containerColor(isPressed: Boolean) = when (this) {
         PRIMARY -> if (isPressed) ReedTheme.colors.bgPrimaryPressed else ReedTheme.colors.bgPrimary
+        PRIMARY_INVERSE_TEXT -> if (isPressed) ReedTheme.colors.bgPrimaryPressed else ReedTheme.colors.bgPrimary
         SECONDARY -> if (isPressed) ReedTheme.colors.bgSecondaryPressed else ReedTheme.colors.bgSecondary
         TERTIARY -> if (isPressed) ReedTheme.colors.bgTertiaryPressed else ReedTheme.colors.bgTertiary
         STROKE -> if (isPressed) ReedTheme.colors.basePrimary else ReedTheme.colors.basePrimary
@@ -21,6 +22,7 @@ enum class ReedButtonColorStyle {
     @Composable
     fun contentColor() = when (this) {
         PRIMARY -> ReedTheme.colors.contentInverse
+        PRIMARY_INVERSE_TEXT -> ReedTheme.colors.contentInverse
         SECONDARY -> ReedTheme.colors.contentPrimary
         TERTIARY -> ReedTheme.colors.contentBrand
         STROKE -> ReedTheme.colors.contentBrand
@@ -31,7 +33,7 @@ enum class ReedButtonColorStyle {
     fun disabledContainerColor() = ReedTheme.colors.bgDisabled
 
     @Composable
-    fun disabledContentColor() = ReedTheme.colors.contentDisabled
+    fun disabledContentColor() = if (this == PRIMARY_INVERSE_TEXT) ReedTheme.colors.contentInverse else ReedTheme.colors.contentDisabled
 
     @Composable
     fun borderStroke() = when (this) {

--- a/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/textfield/InputTransformation.kt
+++ b/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/textfield/InputTransformation.kt
@@ -1,0 +1,19 @@
+package com.ninecraft.booket.core.designsystem.component.textfield
+
+import androidx.compose.foundation.text.input.TextFieldBuffer
+
+/**
+ * 숫자만 허용하고, 01, 00 같은 형식을 막는 InputTransformation
+ */
+val digitOnlyInputTransformation = {
+        text: TextFieldBuffer ->
+    val filtered = text.toString().filter { it.isDigit() }
+
+    val transformed = when {
+        filtered.isEmpty() -> ""
+        filtered == "0" -> "0" // 0 하나만 허용
+        filtered.startsWith("0") -> filtered.trimStart('0') // 선행 0 제거
+        else -> filtered
+    }
+    text.replace(0, text.length, transformed)
+}

--- a/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/textfield/ReedRecordTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/textfield/ReedRecordTextField.kt
@@ -65,7 +65,7 @@ fun ReedRecordTextField(
         Column {
             BasicTextField(
                 state = recordState,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = modifier.fillMaxWidth(),
                 inputTransformation = inputTransformation,
                 textStyle = ReedTheme.typography.body2Medium.copy(color = textColor),
                 keyboardOptions = keyboardOptions,

--- a/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/textfield/ReedRecordTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/textfield/ReedRecordTextField.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
@@ -41,11 +43,14 @@ fun ReedRecordTextField(
     recordState: TextFieldState,
     @StringRes recordHintRes: Int,
     modifier: Modifier = Modifier,
+    inputTransformation: InputTransformation? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions(
         keyboardType = KeyboardType.Text,
         imeAction = ImeAction.Done,
     ),
     lineLimits: TextFieldLineLimits = TextFieldLineLimits.MultiLine(),
+    isError: Boolean = false,
+    errorMessage: String = "",
     onClear: (() -> Unit)? = null,
     onNext: () -> Unit = {},
     backgroundColor: Color = ReedTheme.colors.baseSecondary,
@@ -54,58 +59,70 @@ fun ReedRecordTextField(
     borderStroke: BorderStroke = BorderStroke(width = 1.dp, color = ReedTheme.colors.baseSecondary),
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
+    val errorBorderStroke = BorderStroke(width = 1.dp, color = ReedTheme.colors.borderError)
 
     CompositionLocalProvider(LocalTextSelectionColors provides reedTextSelectionColors) {
-        BasicTextField(
-            state = recordState,
-            modifier = Modifier.fillMaxWidth(),
-            textStyle = ReedTheme.typography.body2Medium.copy(color = textColor),
-            keyboardOptions = keyboardOptions,
-            onKeyboardAction = {
-                if (keyboardOptions.imeAction == ImeAction.Next) {
-                    onNext()
-                } else {
-                    keyboardController?.hide()
-                }
-            },
-            lineLimits = lineLimits,
-            decorator = { innerTextField ->
-                Row(
-                    modifier = modifier
-                        .background(color = backgroundColor, shape = cornerShape)
-                        .border(
-                            border = borderStroke,
-                            shape = cornerShape,
-                        )
-                        .padding(vertical = ReedTheme.spacing.spacing3),
-                    verticalAlignment = if (lineLimits is TextFieldLineLimits.MultiLine) Alignment.Top else Alignment.CenterVertically,
-                ) {
-                    Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing4))
-                    Box(modifier = Modifier.weight(1f)) {
-                        if (recordState.text.isEmpty()) {
-                            Text(
-                                text = stringResource(id = recordHintRes),
-                                color = ReedTheme.colors.contentTertiary,
-                                style = ReedTheme.typography.body2Regular,
+        Column {
+            BasicTextField(
+                state = recordState,
+                modifier = Modifier.fillMaxWidth(),
+                inputTransformation = inputTransformation,
+                textStyle = ReedTheme.typography.body2Medium.copy(color = textColor),
+                keyboardOptions = keyboardOptions,
+                onKeyboardAction = {
+                    if (keyboardOptions.imeAction == ImeAction.Next) {
+                        onNext()
+                    } else {
+                        keyboardController?.hide()
+                    }
+                },
+                lineLimits = lineLimits,
+                decorator = { innerTextField ->
+                    Row(
+                        modifier = modifier
+                            .background(color = backgroundColor, shape = cornerShape)
+                            .border(
+                                border = if (isError) errorBorderStroke else borderStroke,
+                                shape = cornerShape,
+                            )
+                            .padding(vertical = ReedTheme.spacing.spacing3),
+                        verticalAlignment = if (lineLimits is TextFieldLineLimits.MultiLine) Alignment.Top else Alignment.CenterVertically,
+                    ) {
+                        Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing4))
+                        Box(modifier = Modifier.weight(1f)) {
+                            if (recordState.text.isEmpty()) {
+                                Text(
+                                    text = stringResource(id = recordHintRes),
+                                    color = ReedTheme.colors.contentTertiary,
+                                    style = ReedTheme.typography.body2Regular,
+                                )
+                            }
+                            innerTextField()
+                        }
+                        Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing2))
+                        if (recordState.text.toString().isNotEmpty() && onClear != null) {
+                            Icon(
+                                imageVector = ImageVector.vectorResource(R.drawable.ic_x_circle),
+                                contentDescription = "Clear Icon",
+                                modifier = Modifier.clickable {
+                                    onClear()
+                                },
+                                tint = Color.Unspecified,
                             )
                         }
-                        innerTextField()
+                        Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing4))
                     }
-                    Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing2))
-                    if (recordState.text.toString().isNotEmpty() && onClear != null) {
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.ic_x_circle),
-                            contentDescription = "Clear Icon",
-                            modifier = Modifier.clickable {
-                                onClear()
-                            },
-                            tint = Color.Unspecified,
-                        )
-                    }
-                    Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing4))
-                }
-            },
-        )
+                },
+            )
+            if (isError) {
+                Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
+                Text(
+                    text = errorMessage,
+                    color = ReedTheme.colors.contentError,
+                    style = ReedTheme.typography.label2Regular,
+                )
+            }
+        }
     }
 }
 

--- a/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/theme/Color.kt
@@ -64,6 +64,7 @@ val Blue800 = Color(0xFF1269EC)
 val Blue900 = Color(0xFF1F47CD)
 
 val Kakao = Color(0xFFFBD300)
+val Blank = Color(0xFFD6D6D6)
 val HomeBg = Color(0xFFF0F9E8)
 
 // Emotion Color

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBottomSheet.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBottomSheet.kt
@@ -45,8 +45,10 @@ fun ImpressionGuideBottomSheet(
     onCloseButtonClick: () -> Unit,
     onSelectionConfirmButtonClick: () -> Unit,
 ) {
-    val description = if (impressionState.text.isEmpty()) stringResource(R.string.impression_guide_bottomsheet_description) else stringResource(R.string.impression_guide_bottomsheet_warning)
-    val descriptionColor = if (impressionState.text.isEmpty()) ReedTheme.colors.contentSecondary else ReedTheme.colors.contentError
+    val isImpressionEmpty = impressionState.text.isEmpty()
+
+    val description = if (isImpressionEmpty) R.string.impression_guide_description else R.string.impression_guide_warning
+    val descriptionColor = if (isImpressionEmpty) ReedTheme.colors.contentSecondary else ReedTheme.colors.contentError
 
     ReedBottomSheet(
         onDismissRequest = {
@@ -68,7 +70,7 @@ fun ImpressionGuideBottomSheet(
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
-                    text = stringResource(R.string.impression_guide_bottomsheet_title),
+                    text = stringResource(R.string.impression_step_guide),
                     color = ReedTheme.colors.contentPrimary,
                     textAlign = TextAlign.Center,
                     style = ReedTheme.typography.heading2SemiBold,
@@ -83,7 +85,7 @@ fun ImpressionGuideBottomSheet(
             }
             Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing1))
             Text(
-                text = description,
+                text = stringResource(description),
                 modifier = Modifier.fillMaxWidth(),
                 color = descriptionColor,
                 style = ReedTheme.typography.label1Medium,
@@ -91,8 +93,7 @@ fun ImpressionGuideBottomSheet(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = ReedTheme.spacing.spacing5)
-                ,
+                    .padding(vertical = ReedTheme.spacing.spacing5),
                 verticalArrangement = Arrangement.spacedBy(ReedTheme.spacing.spacing2),
             ) {
                 impressionGuideList.forEachIndexed { index, guide ->
@@ -115,7 +116,7 @@ fun ImpressionGuideBottomSheet(
                     colorStyle = ReedButtonColorStyle.PRIMARY,
                     modifier = Modifier.fillMaxWidth(),
                     enabled = selectedImpressionGuide.isNotEmpty(),
-                    text = stringResource(R.string.impression_guide_bottomsheet_selection_confirm),
+                    text = stringResource(R.string.impression_guide_selection_done),
                 )
             } else {
                 ReedButton(
@@ -126,7 +127,7 @@ fun ImpressionGuideBottomSheet(
                     colorStyle = ReedButtonColorStyle.PRIMARY_INVERSE_TEXT,
                     modifier = Modifier.fillMaxWidth(),
                     enabled = beforeSelectedImpressionGuide != selectedImpressionGuide,
-                    text = "변경 완료",
+                    text = stringResource(R.string.impression_guide_change_done),
                 )
             }
             Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing4))

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBottomSheet.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBottomSheet.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.SheetState
@@ -36,12 +37,17 @@ import com.ninecraft.booket.core.designsystem.R as designR
 fun ImpressionGuideBottomSheet(
     onDismissRequest: () -> Unit,
     sheetState: SheetState,
+    impressionState: TextFieldState,
     impressionGuideList: ImmutableList<String>,
+    beforeSelectedImpressionGuide: String,
     selectedImpressionGuide: String,
     onGuideClick: (Int) -> Unit,
     onCloseButtonClick: () -> Unit,
     onSelectionConfirmButtonClick: () -> Unit,
 ) {
+    val description = if (impressionState.text.isEmpty()) stringResource(R.string.impression_guide_bottomsheet_description) else stringResource(R.string.impression_guide_bottomsheet_warning)
+    val descriptionColor = if (impressionState.text.isEmpty()) ReedTheme.colors.contentSecondary else ReedTheme.colors.contentError
+
     ReedBottomSheet(
         onDismissRequest = {
             onDismissRequest()
@@ -75,16 +81,18 @@ fun ImpressionGuideBottomSheet(
                     },
                 )
             }
-            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
+            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing1))
             Text(
-                text = stringResource(R.string.impression_guide_bottomsheet_description),
+                text = description,
                 modifier = Modifier.fillMaxWidth(),
-                color = ReedTheme.colors.contentPrimary,
+                color = descriptionColor,
                 style = ReedTheme.typography.label1Medium,
             )
-            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing5))
             Column(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = ReedTheme.spacing.spacing5)
+                ,
                 verticalArrangement = Arrangement.spacedBy(ReedTheme.spacing.spacing2),
             ) {
                 impressionGuideList.forEachIndexed { index, guide ->
@@ -97,18 +105,30 @@ fun ImpressionGuideBottomSheet(
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing3))
             Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing4))
-            ReedButton(
-                onClick = {
-                    onSelectionConfirmButtonClick()
-                },
-                sizeStyle = largeButtonStyle,
-                colorStyle = ReedButtonColorStyle.PRIMARY,
-                modifier = Modifier.fillMaxWidth(),
-                enabled = selectedImpressionGuide.isNotEmpty(),
-                text = stringResource(R.string.impression_guide_bottomsheet_selection_confirm),
-            )
+            if (impressionState.text.isEmpty()) {
+                ReedButton(
+                    onClick = {
+                        onSelectionConfirmButtonClick()
+                    },
+                    sizeStyle = largeButtonStyle,
+                    colorStyle = ReedButtonColorStyle.PRIMARY,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = selectedImpressionGuide.isNotEmpty(),
+                    text = stringResource(R.string.impression_guide_bottomsheet_selection_confirm),
+                )
+            } else {
+                ReedButton(
+                    onClick = {
+                        onSelectionConfirmButtonClick()
+                    },
+                    sizeStyle = largeButtonStyle,
+                    colorStyle = ReedButtonColorStyle.PRIMARY_INVERSE_TEXT,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = beforeSelectedImpressionGuide != selectedImpressionGuide,
+                    text = "변경 완료",
+                )
+            }
             Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing4))
         }
     }
@@ -138,7 +158,9 @@ private fun ImpressionGuideBottomSheetPreview() {
         ImpressionGuideBottomSheet(
             onDismissRequest = {},
             sheetState = sheetState,
+            impressionState = TextFieldState(),
             impressionGuideList = impressionGuideList,
+            beforeSelectedImpressionGuide = "",
             selectedImpressionGuide = "",
             onGuideClick = {},
             onCloseButtonClick = {},

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBox.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBox.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.ninecraft.booket.core.common.extensions.clickableSingle
+import com.ninecraft.booket.core.common.extensions.noRippleClickable
 import com.ninecraft.booket.core.designsystem.ComponentPreview
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
 import com.ninecraft.booket.core.designsystem.theme.White
@@ -44,7 +45,7 @@ fun ImpressionGuideBox(
                 shape = RoundedCornerShape(ReedTheme.radius.sm),
             )
             .clip(RoundedCornerShape(ReedTheme.radius.sm))
-            .clickableSingle {
+            .noRippleClickable {
                 onClick()
             }
             .padding(

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBox.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/component/ImpressionGuideBox.kt
@@ -12,12 +12,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.ninecraft.booket.core.common.extensions.clickableSingle
 import com.ninecraft.booket.core.common.extensions.noRippleClickable
 import com.ninecraft.booket.core.designsystem.ComponentPreview
+import com.ninecraft.booket.core.designsystem.theme.Blank
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
 import com.ninecraft.booket.core.designsystem.theme.White
 import com.ninecraft.booket.feature.record.R
@@ -56,7 +55,7 @@ fun ImpressionGuideBox(
         Row(verticalAlignment = Alignment.Bottom) {
             Text(
                 text = stringResource(R.string.impression_guide_blank),
-                color = Color(0xFFD6D6D6),
+                color = Blank,
                 style = ReedTheme.typography.label1SemiBold,
             )
             Text(

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/ocr/component/SentenceBox.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/ocr/component/SentenceBox.kt
@@ -2,6 +2,7 @@ package com.ninecraft.booket.feature.record.ocr.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -13,6 +14,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.ninecraft.booket.core.common.extensions.clickableSingle
+import com.ninecraft.booket.core.common.extensions.noRippleClickable
 import com.ninecraft.booket.core.designsystem.ComponentPreview
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
 
@@ -40,7 +42,7 @@ fun SentenceBox(
                 shape = RoundedCornerShape(ReedTheme.radius.sm),
             )
             .clip(RoundedCornerShape(ReedTheme.radius.sm))
-            .clickableSingle {
+            .noRippleClickable {
                 onClick()
             }
             .padding(

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/ocr/component/SentenceBox.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/ocr/component/SentenceBox.kt
@@ -2,7 +2,6 @@ package com.ninecraft.booket.feature.record.ocr.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -13,7 +12,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.ninecraft.booket.core.common.extensions.clickableSingle
 import com.ninecraft.booket.core.common.extensions.noRippleClickable
 import com.ninecraft.booket.core.designsystem.ComponentPreview
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.text.TextRange
 import com.ninecraft.booket.core.common.utils.handleException
 import com.ninecraft.booket.core.data.api.repository.RecordRepository
 import com.ninecraft.booket.core.designsystem.EmotionTag
@@ -184,6 +185,7 @@ class RecordRegisterPresenter @AssistedInject constructor(
                     impressionState.edit {
                         replace(0, length, "")
                         append(selectedImpressionGuide)
+                        this.selection = TextRange(0) // 커서를 문장 맨 앞에 위치
                     }
                     isImpressionGuideBottomSheetVisible = false
                 }

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
@@ -59,6 +59,7 @@ class RecordRegisterPresenter @AssistedInject constructor(
         val emotionTags by rememberRetained { mutableStateOf(EmotionTag.entries.toPersistentList()) }
         var selectedEmotion by rememberRetained { mutableStateOf<EmotionTag?>(null) }
         var selectedImpressionGuide by rememberRetained { mutableStateOf("") }
+        var beforeSelectedImpressionGuide by rememberRetained { mutableStateOf(selectedImpressionGuide) }
         val impressionState = rememberTextFieldState()
         var isImpressionGuideBottomSheetVisible by rememberRetained { mutableStateOf(false) }
         var isExitDialogVisible by rememberRetained { mutableStateOf(false) }
@@ -165,9 +166,9 @@ class RecordRegisterPresenter @AssistedInject constructor(
                 }
 
                 is RecordRegisterUiEvent.OnImpressionGuideButtonClick -> {
-                    selectedImpressionGuide = ""
-                    impressionState.edit {
-                        replace(0, length, "")
+                    beforeSelectedImpressionGuide = selectedImpressionGuide
+                    if (impressionState.text.isEmpty()) {
+                        selectedImpressionGuide = ""
                     }
                     isImpressionGuideBottomSheetVisible = true
                 }
@@ -176,14 +177,16 @@ class RecordRegisterPresenter @AssistedInject constructor(
                     val index = event.index
                     if (index in impressionGuideList.indices) {
                         selectedImpressionGuide = impressionGuideList[index]
-                        impressionState.edit {
-                            replace(0, length, "")
-                            append(selectedImpressionGuide)
-                        }
                     }
                 }
 
-                is RecordRegisterUiEvent.OnSelectionConfirmed -> {}
+                is RecordRegisterUiEvent.OnImpressionGuideConfirmed -> {
+                    impressionState.edit {
+                        replace(0, length, "")
+                        append(selectedImpressionGuide)
+                    }
+                    isImpressionGuideBottomSheetVisible = false
+                }
 
                 is RecordRegisterUiEvent.OnImpressionGuideBottomSheetDismiss -> {
                     isImpressionGuideBottomSheetVisible = false
@@ -234,6 +237,7 @@ class RecordRegisterPresenter @AssistedInject constructor(
             impressionState = impressionState,
             impressionGuideList = impressionGuideList,
             selectedImpressionGuide = selectedImpressionGuide,
+            beforeSelectedImpressionGuide = beforeSelectedImpressionGuide,
             isNextButtonEnabled = isNextButtonEnabled,
             isImpressionGuideBottomSheetVisible = isImpressionGuideBottomSheetVisible,
             isExitDialogVisible = isExitDialogVisible,

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
@@ -63,11 +63,17 @@ class RecordRegisterPresenter @AssistedInject constructor(
         var isImpressionGuideBottomSheetVisible by rememberRetained { mutableStateOf(false) }
         var isExitDialogVisible by rememberRetained { mutableStateOf(false) }
         var isRecordSavedDialogVisible by rememberRetained { mutableStateOf(false) }
+        val isPageError by remember {
+            derivedStateOf {
+                val page = recordPageState.text.toString().toIntOrNull() ?: 0
+                page > MAX_PAGE
+            }
+        }
         val isNextButtonEnabled by remember {
             derivedStateOf {
                 when (currentStep) {
                     RecordStep.QUOTE -> {
-                        recordPageState.text.isNotEmpty() && recordSentenceState.text.isNotEmpty()
+                        recordPageState.text.isNotEmpty() && recordSentenceState.text.isNotEmpty() && !isPageError
                     }
                     RecordStep.EMOTION -> {
                         selectedEmotion != null
@@ -222,6 +228,7 @@ class RecordRegisterPresenter @AssistedInject constructor(
             currentStep = currentStep,
             recordPageState = recordPageState,
             recordSentenceState = recordSentenceState,
+            isPageError = isPageError,
             emotionTags = emotionTags,
             selectedEmotion = selectedEmotion,
             impressionState = impressionState,
@@ -243,5 +250,9 @@ class RecordRegisterPresenter @AssistedInject constructor(
             screen: RecordScreen,
             navigator: Navigator,
         ): RecordRegisterPresenter
+    }
+
+    companion object {
+        const val MAX_PAGE = 1000
     }
 }

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
@@ -81,7 +81,7 @@ internal fun RecordRegister(
                 .padding(horizontal = ReedTheme.spacing.spacing5),
             enabled = state.isNextButtonEnabled,
             text = stringResource(R.string.record_next_button),
-            multipleEventsCutterEnabled = state.currentStep == RecordStep.IMPRESSION
+            multipleEventsCutterEnabled = state.currentStep == RecordStep.IMPRESSION,
         )
         Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing4))
     }

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
@@ -81,6 +81,7 @@ internal fun RecordRegister(
                 .padding(horizontal = ReedTheme.spacing.spacing5),
             enabled = state.isNextButtonEnabled,
             text = stringResource(R.string.record_next_button),
+            multipleEventsCutterEnabled = state.currentStep == RecordStep.IMPRESSION
         )
         Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing4))
     }

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUiState.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUiState.kt
@@ -13,6 +13,7 @@ data class RecordRegisterUiState(
     val currentStep: RecordStep = RecordStep.QUOTE,
     val recordPageState: TextFieldState = TextFieldState(),
     val recordSentenceState: TextFieldState = TextFieldState(),
+    val isPageError: Boolean = false,
     val emotionTags: ImmutableList<EmotionTag> = persistentListOf(),
     val selectedEmotion: EmotionTag? = null,
     val impressionState: TextFieldState = TextFieldState(),

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUiState.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUiState.kt
@@ -19,6 +19,7 @@ data class RecordRegisterUiState(
     val impressionState: TextFieldState = TextFieldState(),
     val impressionGuideList: ImmutableList<String> = persistentListOf(),
     val selectedImpressionGuide: String = "",
+    val beforeSelectedImpressionGuide: String = "",
     val isNextButtonEnabled: Boolean = false,
     val isImpressionGuideBottomSheetVisible: Boolean = false,
     val isExitDialogVisible: Boolean = false,
@@ -43,7 +44,7 @@ sealed interface RecordRegisterUiEvent : CircuitUiEvent {
     data object OnImpressionGuideButtonClick : RecordRegisterUiEvent
     data object OnImpressionGuideBottomSheetDismiss : RecordRegisterUiEvent
     data class OnSelectImpressionGuide(val index: Int) : RecordRegisterUiEvent
-    data object OnSelectionConfirmed : RecordRegisterUiEvent
+    data object OnImpressionGuideConfirmed : RecordRegisterUiEvent
     data object OnExitDialogConfirm : RecordRegisterUiEvent
     data object OnExitDialogDismiss : RecordRegisterUiEvent
     data object OnRecordSavedDialogConfirm : RecordRegisterUiEvent

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
@@ -11,10 +11,15 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
@@ -41,6 +46,16 @@ fun ImpressionStep(
     val impressionGuideBottomSheetState =
         rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
+    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    LaunchedEffect(Unit) {
+        if (state.impressionState.text.isEmpty()) {
+            focusRequester.requestFocus()
+            keyboardController?.show()
+        }
+    }
+
     Column(
         modifier = modifier
             .background(White)
@@ -63,6 +78,7 @@ fun ImpressionStep(
             recordHintRes = R.string.impression_step_hint,
             modifier = Modifier
                 .fillMaxWidth()
+                .focusRequester(focusRequester)
                 .height(140.dp),
         )
         Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing3))

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
@@ -89,7 +89,9 @@ fun ImpressionStep(
                 state.eventSink(RecordRegisterUiEvent.OnImpressionGuideBottomSheetDismiss)
             },
             sheetState = impressionGuideBottomSheetState,
+            impressionState = state.impressionState,
             impressionGuideList = state.impressionGuideList,
+            beforeSelectedImpressionGuide = state.beforeSelectedImpressionGuide,
             selectedImpressionGuide = state.selectedImpressionGuide,
             onGuideClick = {
                 state.eventSink(RecordRegisterUiEvent.OnSelectImpressionGuide(it))
@@ -103,7 +105,7 @@ fun ImpressionStep(
             onSelectionConfirmButtonClick = {
                 coroutineScope.launch {
                     impressionGuideBottomSheetState.hide()
-                    state.eventSink(RecordRegisterUiEvent.OnImpressionGuideBottomSheetDismiss)
+                    state.eventSink(RecordRegisterUiEvent.OnImpressionGuideConfirmed)
                 }
             },
         )

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/QuoteStep.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/QuoteStep.kt
@@ -18,15 +18,14 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import com.ninecraft.booket.core.designsystem.component.textfield.digitOnlyInputTransformation
 import com.ninecraft.booket.core.designsystem.ComponentPreview
 import com.ninecraft.booket.core.designsystem.component.button.ReedButton
 import com.ninecraft.booket.core.designsystem.component.button.ReedButtonColorStyle
 import com.ninecraft.booket.core.designsystem.component.button.smallRoundedButtonStyle
 import com.ninecraft.booket.core.designsystem.component.textfield.ReedRecordTextField
+import com.ninecraft.booket.core.designsystem.component.textfield.digitOnlyInputTransformation
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
 import com.ninecraft.booket.core.designsystem.theme.White
 import com.ninecraft.booket.feature.record.R

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/QuoteStep.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/QuoteStep.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.ninecraft.booket.core.designsystem.component.textfield.digitOnlyInputTransformation
 import com.ninecraft.booket.core.designsystem.ComponentPreview
 import com.ninecraft.booket.core.designsystem.component.button.ReedButton
 import com.ninecraft.booket.core.designsystem.component.button.ReedButtonColorStyle
@@ -59,11 +60,11 @@ internal fun QuoteStep(
         ReedRecordTextField(
             recordState = state.recordPageState,
             recordHintRes = R.string.quote_step_page_hint,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number,
-                imeAction = ImeAction.Next,
-            ),
+            inputTransformation = digitOnlyInputTransformation,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             lineLimits = TextFieldLineLimits.SingleLine,
+            isError = state.isPageError,
+            errorMessage = stringResource(R.string.quote_step_page_input_error),
             onClear = {
                 state.eventSink(RecordRegisterUiEvent.OnClearClick)
             },

--- a/feature/record/src/main/res/values/strings.xml
+++ b/feature/record/src/main/res/values/strings.xml
@@ -37,4 +37,5 @@
     <string name="record_saved_dialog_description">방금 남긴 기록을 확인해볼까요?</string>
     <string name="record_saved_dialog_move_to_detail">기록 보러가기</string>
     <string name="record_saved_dialog_close">닫기</string>
+    <string name="quote_step_page_input_error">해당 책의 마지막 페이지 수를 초과했습니다</string>
 </resources>

--- a/feature/record/src/main/res/values/strings.xml
+++ b/feature/record/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="impression_step_guide">감상평 가이드</string>
     <string name="impression_guide_bottomsheet_title">감상평 가이드</string>
     <string name="impression_guide_bottomsheet_description">아래 문장 중 하나를 선택해 이어서 감상을 적어보세요</string>
+    <string name="impression_guide_bottomsheet_warning">새로운 가이드를 선택하면 기존 내용은 사라져요</string>
     <string name="impression_guide_bottomsheet_selection_confirm">선택 완료</string>
     <string name="impression_guide_blank">______</string>
     <string name="record_saved_dialog_title">기록이 저장되었어요!</string>

--- a/feature/record/src/main/res/values/strings.xml
+++ b/feature/record/src/main/res/values/strings.xml
@@ -29,10 +29,10 @@
     <string name="impression_step_description">감상평 가이드로 쉽게 남길 수 있어요</string>
     <string name="impression_step_hint">내용을 입력해주세요.</string>
     <string name="impression_step_guide">감상평 가이드</string>
-    <string name="impression_guide_bottomsheet_title">감상평 가이드</string>
-    <string name="impression_guide_bottomsheet_description">아래 문장 중 하나를 선택해 이어서 감상을 적어보세요</string>
-    <string name="impression_guide_bottomsheet_warning">새로운 가이드를 선택하면 기존 내용은 사라져요</string>
-    <string name="impression_guide_bottomsheet_selection_confirm">선택 완료</string>
+    <string name="impression_guide_description">아래 문장 중 하나를 선택해 이어서 감상을 적어보세요</string>
+    <string name="impression_guide_warning">새로운 가이드를 선택하면 기존 내용은 사라져요</string>
+    <string name="impression_guide_selection_done">선택 완료</string>
+    <string name="impression_guide_change_done">변경 완료</string>
     <string name="impression_guide_blank">______</string>
     <string name="record_saved_dialog_title">기록이 저장되었어요!</string>
     <string name="record_saved_dialog_description">방금 남긴 기록을 확인해볼까요?</string>


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #84 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- multipleEventsCutter로 터치 씹히던 부분 수정
- 페이지 입력 TextField에서 유효한 번호만 입력되도록 구현
- 최대 페이지 넘어갈 시 error message 뜨도록 구현 (현재 임시로 `MAX_PAGE = 1000`으로 설정)
- 감상평 가이드 진입 시 기존 작성한 내용이 없으면 키보드 올라오도록 구현
- 감상평 가이드 재선택 관련 정책 적용
- 감상평 가이드 선택 시 커서가 문장 가장 앞에 오도록 구현

## 🧪 테스트 내역
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
### ✅ 페이지 입력 유효성 검사

https://github.com/user-attachments/assets/a89a5057-d538-45f1-be34-8583526f02cb


### ✅ 감상평 가이드 진입 시 키보드

https://github.com/user-attachments/assets/e94658e2-8732-4a19-9990-793cbf66fdab


### ✅ TEST CASE 1: 선택한 가이드가 있는 상태에서 감상평 가이드 누른 경우

https://github.com/user-attachments/assets/efd5d08c-86cd-4f33-a140-1efbf203bdfa


### ✅ TEST CASE 2: 작성한 내용 있는 상태에서 감상평 가이드 누른 경우

https://github.com/user-attachments/assets/b326936a-d7be-4941-a4c9-b9a254f4936d


### ✅ TEST CASE 3: 기존에 있던 내용을 지우고 감상평 가이드 누른 경우

https://github.com/user-attachments/assets/f0633e01-fb15-4146-bac3-1c31a83cf830


## 💬 추가 설명 or 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 문장 수집 화면에서는 페이지 입력, 문장 입력, 문장 스캔 중 사용자의 입력 순서를 제한하지 않기 위해, 특정 TextField에 자동 포커스를 설정하지 않았습니다.
- 감상평 가이드 정책사항 관련 PM 체크가 필요해서 먼저 pr올려요! 키보드 바깥 영역 터치 부분은 마저 작업해서 커밋하겠습니다~
