### PR TITLE
fix: Dialog 혹은 BottomSheet를 통해 navigation 하는 경우 해당 컴포넌트가 닫히기 전 화면이 먼저 전환되는 문제 임시 해결

### DIFF
--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
@@ -18,6 +18,7 @@ import com.ninecraft.booket.feature.screens.LoginScreen
 import com.ninecraft.booket.feature.screens.OcrScreen
 import com.ninecraft.booket.feature.screens.RecordDetailScreen
 import com.ninecraft.booket.feature.screens.RecordScreen
+import com.ninecraft.booket.feature.screens.delayedPop
 import com.orhanobut.logger.Logger
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.foundation.rememberAnsweringNavigator
@@ -151,7 +152,9 @@ class RecordRegisterPresenter @AssistedInject constructor(
 
                 is RecordRegisterUiEvent.OnExitDialogConfirm -> {
                     isExitDialogVisible = false
-                    navigator.pop()
+                    scope.launch {
+                        navigator.delayedPop()
+                    }
                 }
 
                 is RecordRegisterUiEvent.OnExitDialogDismiss -> {
@@ -224,7 +227,9 @@ class RecordRegisterPresenter @AssistedInject constructor(
 
                 is RecordRegisterUiEvent.OnRecordSavedDialogDismiss -> {
                     isRecordSavedDialogVisible = false
-                    navigator.pop()
+                    scope.launch {
+                        navigator.delayedPop()
+                    }
                 }
             }
         }

--- a/feature/screens/src/main/kotlin/com/ninecraft/booket/feature/screens/extensions.kt
+++ b/feature/screens/src/main/kotlin/com/ninecraft/booket/feature/screens/extensions.kt
@@ -1,0 +1,14 @@
+package com.ninecraft.booket.feature.screens
+
+import com.slack.circuit.runtime.Navigator
+import kotlinx.coroutines.delay
+
+suspend fun Navigator.delayedGoTo(screen: ReedScreen, delayMillis: Long = 200L) {
+    delay(delayMillis)
+    goTo(screen)
+}
+
+suspend fun Navigator.delayedPop(delayMillis: Long = 200L) {
+    delay(delayMillis)
+    pop()
+}

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/SearchPresenter.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/SearchPresenter.kt
@@ -17,6 +17,7 @@ import com.ninecraft.booket.core.ui.component.FooterState
 import com.ninecraft.booket.feature.screens.LoginScreen
 import com.ninecraft.booket.feature.screens.RecordScreen
 import com.ninecraft.booket.feature.screens.SearchScreen
+import com.ninecraft.booket.feature.screens.delayedGoTo
 import com.orhanobut.logger.Logger
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.retained.collectAsRetainedState
@@ -191,7 +192,9 @@ class SearchPresenter @AssistedInject constructor(
 
                 is SearchUiEvent.OnBookRegisterSuccessOkButtonClick -> {
                     isBookRegisterSuccessBottomSheetVisible = false
-                    navigator.goTo(RecordScreen(registeredUserBookId))
+                    scope.launch {
+                        navigator.delayedGoTo(RecordScreen(registeredUserBookId))
+                    }
                 }
 
                 is SearchUiEvent.OnBookRegisterSuccessCancelButtonClick -> {


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #93 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- `feature:screen`에 delayedNavigator 확장함수 추가
- 주요 문제가 있었던 화면(검색, 기록등록)에 적용

## 🧪 테스트 내역
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

https://github.com/user-attachments/assets/1b905a04-8671-4798-a339-31ccc8506b10


## 💬 추가 설명 or 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 매끄럽게 잘 동작하는 부분에는 해당 확장함수를 따로 적용하지 않았슴다
- 나중에 더 세련된 방법으로 고칩시다!!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 화면 전환 시 약간의 지연 효과가 추가되어 더욱 부드러운 네비게이션 경험을 제공합니다.

* **버그 수정**
  * 일부 화면에서 즉시 이동하던 네비게이션이 비동기 방식으로 처리되어 사용자 경험이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->