### PR TITLE
feat: 회원 탈퇴 API 연동

### DIFF
--- a/core/data/api/src/main/kotlin/com/ninecraft/booket/core/data/api/repository/AuthRepository.kt
+++ b/core/data/api/src/main/kotlin/com/ninecraft/booket/core/data/api/repository/AuthRepository.kt
@@ -8,6 +8,8 @@ interface AuthRepository {
 
     suspend fun logout(): Result<Unit>
 
+    suspend fun withdraw(): Result<Unit>
+
     suspend fun agreeTerms(termsAgreed: Boolean): Result<Unit>
 
     val autoLoginState: Flow<AutoLoginState>

--- a/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/repository/DefaultAuthRepository.kt
+++ b/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/repository/DefaultAuthRepository.kt
@@ -31,6 +31,11 @@ internal class DefaultAuthRepository @Inject constructor(
         clearTokens()
     }
 
+    override suspend fun withdraw() = runSuspendCatching {
+        service.withdraw()
+        clearTokens()
+    }
+
     override suspend fun agreeTerms(termsAgreed: Boolean) = runSuspendCatching {
         service.agreeTerms(TermsAgreementRequest(termsAgreed))
         Unit

--- a/core/network/src/main/kotlin/com/ninecraft/booket/core/network/service/ReedService.kt
+++ b/core/network/src/main/kotlin/com/ninecraft/booket/core/network/service/ReedService.kt
@@ -17,6 +17,7 @@ import com.ninecraft.booket.core.network.response.RefreshTokenResponse
 import com.ninecraft.booket.core.network.response.TermsAgreementResponse
 import com.ninecraft.booket.core.network.response.UserProfileResponse
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.PUT
@@ -35,10 +36,14 @@ interface ReedService {
     @POST("api/v1/auth/signout")
     suspend fun logout()
 
-    @PUT("api/v1/auth/terms-agreement")
+    @DELETE("api/v1/auth/withdraw")
+    suspend fun withdraw()
+
+    // User endpoints (auth required)
+    @PUT("api/v1/users/me/terms-agreement")
     suspend fun agreeTerms(@Body termsAgreementRequest: TermsAgreementRequest): TermsAgreementResponse
 
-    @GET("api/v1/auth/me")
+    @GET("api/v1/users/me")
     suspend fun getUserProfile(): UserProfileResponse
 
     // Book endpoints (auth required)

--- a/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/SettingsPresenter.kt
+++ b/feature/settings/src/main/kotlin/com/ninecraft/booket/feature/settings/SettingsPresenter.kt
@@ -105,7 +105,32 @@ class SettingsPresenter @AssistedInject constructor(
                 }
 
                 is SettingsUiEvent.Withdraw -> {
-                    // TODO: 회원탈퇴 처리 -> 성공 시 로그인 화면으로 이동
+                    scope.launch {
+                        try {
+                            isLoading = true
+                            authRepository.withdraw()
+                                .onSuccess {
+                                    navigator.resetRoot(LoginScreen)
+                                }
+                                .onFailure { exception ->
+                                    val handleErrorMessage = { message: String ->
+                                        Logger.e(message)
+                                        sideEffect = SettingsSideEffect.ShowToast(message)
+                                    }
+
+                                    handleException(
+                                        exception = exception,
+                                        onError = handleErrorMessage,
+                                        onLoginRequired = {
+                                            navigator.resetRoot(LoginScreen)
+                                        },
+                                    )
+                                }
+                        } finally {
+                            isLoading = false
+                        }
+                    }
+                    isWithdrawBottomSheetVisible = false
                 }
             }
         }


### PR DESCRIPTION
약관 동의 상태 업데이트, 사용자 프로필 조회 API endpoint 변경 반영

<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close https://github.com/YAPP-Github/Reed-Android/issues/103

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 회원탈퇴 API 연동 및 회원탈퇴 플로우 구현 

## 🧪 테스트 내역 (선택)
- [ ] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| 기능 설명 |<img src="링크" width="300" />| 기능 설명 |<img src="링크" width="300" />|

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 카카오 회원탈퇴 API 환경이 서버에 구축되면, 정상 동작할듯합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원 탈퇴 기능이 추가되었습니다. 설정 화면에서 탈퇴를 진행할 수 있습니다.

* **버그 수정**
  * 회원 정보 및 약관 동의 관련 일부 경로가 변경되어 더 정확한 사용자 정보 처리가 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->