### PR TITLE
feat: 에러 핸들링 및 공통 UI 처리

### DIFF
--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/constants/ErrorDialogSpec.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/constants/ErrorDialogSpec.kt
@@ -1,0 +1,7 @@
+package com.ninecraft.booket.core.common.constants
+
+data class ErrorDialogSpec(
+    val message: String,
+    val buttonLabel: String,
+    val action: () -> Unit,
+)

--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/constants/ErrorScope.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/constants/ErrorScope.kt
@@ -1,0 +1,5 @@
+package com.ninecraft.booket.core.common.constants
+
+enum class ErrorScope {
+    GLOBAL, LOGIN, BOOK_REGISTER, RECORD_REGISTER
+}

--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/event/ErrorEventHelper.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/event/ErrorEventHelper.kt
@@ -1,0 +1,22 @@
+package com.ninecraft.booket.core.common.event
+
+import com.ninecraft.booket.core.common.constants.ErrorDialogSpec
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import java.util.UUID
+
+object ErrorEventHelper {
+    private val _errorEvent = Channel<ErrorEvent>(DEFAULT_BUFFER_SIZE)
+    val errorEvent = _errorEvent.receiveAsFlow()
+
+    fun sendError(event: ErrorEvent) {
+        _errorEvent.trySend(event)
+    }
+}
+
+sealed interface ErrorEvent {
+    data class ShowDialog(
+        val spec: ErrorDialogSpec,
+        val key: String = UUID.randomUUID().toString()
+    ) : ErrorEvent
+}

--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/event/ErrorEventHelper.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/event/ErrorEventHelper.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import java.util.UUID
 
 object ErrorEventHelper {
-    private val _errorEvent = Channel<ErrorEvent>(DEFAULT_BUFFER_SIZE)
+    private val _errorEvent = Channel<ErrorEvent>(Channel.BUFFERED)
     val errorEvent = _errorEvent.receiveAsFlow()
 
     fun sendError(event: ErrorEvent) {

--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/event/ErrorEventHelper.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/event/ErrorEventHelper.kt
@@ -17,6 +17,6 @@ object ErrorEventHelper {
 sealed interface ErrorEvent {
     data class ShowDialog(
         val spec: ErrorDialogSpec,
-        val key: String = UUID.randomUUID().toString()
+        val key: String = UUID.randomUUID().toString(),
     ) : ErrorEvent
 }

--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/utils/HandleException.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/utils/HandleException.kt
@@ -66,6 +66,7 @@ private fun buildDialog(
         exception.isNetworkError() -> {
             "네트워크 연결이 불안정합니다.\n인터넷 연결을 확인해주세요"
         }
+
         exception is HttpException -> {
             when (scope) {
                 ErrorScope.GLOBAL -> {
@@ -85,12 +86,13 @@ private fun buildDialog(
                 }
             }
         }
+
         else -> {
             "알 수 없는 문제가 발생했어요.\n다시 시도해주세요"
         }
     }
 
-    return ErrorDialogSpec(message = message, buttonLabel ="확인" , action = action)
+    return ErrorDialogSpec(message = message, buttonLabel = "확인", action = action)
 }
 
 @Suppress("TooGenericExceptionCaught")

--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/utils/HandleException.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/utils/HandleException.kt
@@ -1,5 +1,9 @@
 package com.ninecraft.booket.core.common.utils
 
+import com.ninecraft.booket.core.common.constants.ErrorDialogSpec
+import com.ninecraft.booket.core.common.constants.ErrorScope
+import com.ninecraft.booket.core.common.event.ErrorEvent
+import com.ninecraft.booket.core.common.event.ErrorEventHelper
 import com.ninecraft.booket.core.network.response.ErrorResponse
 import com.orhanobut.logger.Logger
 import kotlinx.serialization.SerializationException
@@ -39,6 +43,56 @@ fun handleException(
     }
 }
 
+fun postErrorDialog(
+    errorScope: ErrorScope,
+    exception: Throwable,
+    action: () -> Unit = {},
+) {
+    val spec = buildDialog(
+        scope = errorScope,
+        exception = exception,
+        action = action,
+    )
+
+    ErrorEventHelper.sendError(event = ErrorEvent.ShowDialog(spec))
+}
+
+private fun buildDialog(
+    scope: ErrorScope,
+    exception: Throwable,
+    action: () -> Unit,
+): ErrorDialogSpec {
+    val message = when {
+        exception.isNetworkError() -> {
+            "네트워크 연결이 불안정합니다.\n인터넷 연결을 확인해주세요"
+        }
+        exception is HttpException -> {
+            when (scope) {
+                ErrorScope.GLOBAL -> {
+                    "알 수 없는 문제가 발생했어요.\n다시 시도해주세요"
+                }
+
+                ErrorScope.LOGIN -> {
+                    "예기치 않은 오류가 발생했습니다.\n다시 로그인 해주세요."
+                }
+
+                ErrorScope.BOOK_REGISTER -> {
+                    "도서 등록 중 오류가 발생했어요.\n다시 시도해주세요"
+                }
+
+                ErrorScope.RECORD_REGISTER -> {
+                    "기록 저장에 실패했어요.\n다시 시도해주세요"
+                }
+            }
+        }
+        else -> {
+            "알 수 없는 문제가 발생했어요.\n다시 시도해주세요"
+        }
+    }
+
+    return ErrorDialogSpec(message = message, buttonLabel ="확인" , action = action)
+}
+
 @Suppress("TooGenericExceptionCaught")
 private fun HttpException.parseErrorMessage(): String? {
     return try {
@@ -69,7 +123,7 @@ private fun getHttpErrorMessage(statusCode: Int): String {
     }
 }
 
-private fun Throwable.isNetworkError(): Boolean {
+fun Throwable.isNetworkError(): Boolean {
     return this is UnknownHostException ||
         this is ConnectException ||
         this is SocketTimeoutException ||

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -12,6 +12,7 @@ android {
 dependencies {
     implementations(
         projects.core.designsystem,
+        projects.core.common,
 
         libs.compose.keyboard.state,
         libs.logger,

--- a/core/ui/src/main/kotlin/com/ninecraft/booket/core/ui/component/ReedDialog.kt
+++ b/core/ui/src/main/kotlin/com/ninecraft/booket/core/ui/component/ReedDialog.kt
@@ -24,10 +24,10 @@ import com.ninecraft.booket.core.designsystem.theme.ReedTheme
 
 @Composable
 fun ReedDialog(
-    title: String,
     confirmButtonText: String,
     onConfirmRequest: () -> Unit,
     modifier: Modifier = Modifier,
+    title: String? = null,
     description: String? = null,
     dismissButtonText: String? = null,
     onDismissRequest: () -> Unit = {},
@@ -63,14 +63,16 @@ fun ReedDialog(
                 it()
                 Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing6))
             }
-            Text(
-                text = title,
-                color = ReedTheme.colors.contentPrimary,
-                textAlign = TextAlign.Center,
-                style = ReedTheme.typography.headline1SemiBold,
-            )
-            description?.let {
+            title?.let {
+                Text(
+                    text = title,
+                    color = ReedTheme.colors.contentPrimary,
+                    textAlign = TextAlign.Center,
+                    style = ReedTheme.typography.headline1SemiBold,
+                )
                 Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
+            }
+            description?.let {
                 Text(
                     text = description,
                     color = ReedTheme.colors.contentSecondary,

--- a/core/ui/src/main/kotlin/com/ninecraft/booket/core/ui/component/ReedErrorUi.kt
+++ b/core/ui/src/main/kotlin/com/ninecraft/booket/core/ui/component/ReedErrorUi.kt
@@ -1,0 +1,66 @@
+package com.ninecraft.booket.core.ui.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import com.ninecraft.booket.core.common.utils.isNetworkError
+import com.ninecraft.booket.core.designsystem.ComponentPreview
+import com.ninecraft.booket.core.designsystem.component.button.ReedButton
+import com.ninecraft.booket.core.designsystem.component.button.ReedButtonColorStyle
+import com.ninecraft.booket.core.designsystem.component.button.mediumButtonStyle
+import com.ninecraft.booket.core.designsystem.theme.ReedTheme
+import com.ninecraft.booket.core.ui.R
+
+@Composable
+fun ReedErrorUi(
+    exception: Throwable,
+    onRetryClick: () -> Unit,
+) {
+    val message = if (exception.isNetworkError()) stringResource(R.string.network_error_message) else stringResource(R.string.server_error_message)
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = message,
+                color = ReedTheme.colors.contentSecondary,
+                textAlign = TextAlign.Center,
+                style = ReedTheme.typography.body1Medium,
+            )
+            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing6))
+            ReedButton(
+                onClick = { onRetryClick() },
+                text = stringResource(R.string.retry),
+                colorStyle = ReedButtonColorStyle.PRIMARY,
+                sizeStyle = mediumButtonStyle,
+            )
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun ReedNetworkErrorUiPreview() {
+    ReedErrorUi(
+        exception = java.io.IOException("네트워크 오류"),
+        onRetryClick = {},
+    )
+}
+
+@ComponentPreview
+@Composable
+private fun ReedServerErrorUiPreview() {
+    ReedErrorUi(
+        exception = Exception("알 수 없는 문제"),
+        onRetryClick = {},
+    )
+}

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
 <resources>
     <string name="no_more_result">더 이상 결과가 없습니다</string>
     <string name="retry">다시 시도</string>
+    <string name="network_error_message">네트워크 연결이 불안정합니다.\n인터넷 연결을 확인해주세요</string>
+    <string name="server_error_message">알 수 없는 문제가 발생했어요.\n다시 시도해주세요</string>
 </resources>

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailPresenter.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailPresenter.kt
@@ -195,7 +195,7 @@ class BookDetailPresenter @AssistedInject constructor(
                 }
 
                 is BookDetailUiEvent.OnRegisterRecordButtonClick -> {
-                    navigator.goTo(RecordScreen(""))
+                    navigator.goTo(RecordScreen(screen.userBookId))
                 }
 
                 is BookDetailUiEvent.OnRecordSortButtonClick -> {

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailPresenter.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailPresenter.kt
@@ -98,6 +98,9 @@ class BookDetailPresenter @AssistedInject constructor(
                     seedsStates = seeds.categories.toImmutableList()
                     readingRecords = records.content.toPersistentList()
 
+                    isLastPage = records.content.size < PAGE_SIZE
+                    currentStartIndex = START_INDEX
+
                     uiState = UiState.Success
                 }
             } catch (ce: CancellationException) {

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailPresenter.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailPresenter.kt
@@ -74,6 +74,7 @@ class BookDetailPresenter @AssistedInject constructor(
         var isRecordSortBottomSheetVisible by rememberRetained { mutableStateOf(false) }
         var sideEffect by rememberRetained { mutableStateOf<BookDetailSideEffect?>(null) }
 
+        @Suppress("TooGenericExceptionCaught")
         suspend fun initialLoad() {
             uiState = UiState.Loading
 

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailPresenter.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailPresenter.kt
@@ -8,7 +8,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import com.ninecraft.booket.core.common.constants.BookStatus
+import com.ninecraft.booket.core.common.constants.ErrorScope
 import com.ninecraft.booket.core.common.utils.handleException
+import com.ninecraft.booket.core.common.utils.postErrorDialog
 import com.ninecraft.booket.core.data.api.repository.BookRepository
 import com.ninecraft.booket.core.data.api.repository.RecordRepository
 import com.ninecraft.booket.core.model.BookDetailModel
@@ -32,6 +34,9 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 
@@ -69,50 +74,48 @@ class BookDetailPresenter @AssistedInject constructor(
         var isRecordSortBottomSheetVisible by rememberRetained { mutableStateOf(false) }
         var sideEffect by rememberRetained { mutableStateOf<BookDetailSideEffect?>(null) }
 
-        fun getSeedsStats() {
-            scope.launch {
-                bookRepository.getSeedsStats(screen.userBookId)
-                    .onSuccess { result ->
-                        seedsStates = result.categories.toImmutableList()
-                    }
-                    .onFailure { exception ->
-                        val handleErrorMessage = { message: String ->
-                            Logger.e(message)
-                            sideEffect = BookDetailSideEffect.ShowToast(message)
-                        }
+        suspend fun initialLoad() {
+            uiState = UiState.Loading
 
-                        handleException(
-                            exception = exception,
-                            onError = handleErrorMessage,
-                            onLoginRequired = {
-                                navigator.resetRoot(LoginScreen)
-                            },
-                        )
+            try {
+                coroutineScope {
+                    val bookDetailDef = async { bookRepository.getBookDetail(screen.isbn13).getOrThrow() }
+                    val seedsDef = async { bookRepository.getSeedsStats(screen.userBookId).getOrThrow() }
+                    val readingRecordsDef = async {
+                        recordRepository.getReadingRecords(
+                            userBookId = screen.userBookId,
+                            sort = currentRecordSort.value,
+                            page = START_INDEX,
+                            size = PAGE_SIZE,
+                        ).getOrThrow()
                     }
-            }
-        }
+                    val detail = bookDetailDef.await()
+                    val seeds = seedsDef.await()
+                    val records = readingRecordsDef.await()
 
-        fun getBookDetail() {
-            scope.launch {
-                bookRepository.getBookDetail(screen.isbn13)
-                    .onSuccess { result ->
-                        bookDetail = result
-                        currentBookStatus = BookStatus.fromValue(result.userBookStatus) ?: BookStatus.BEFORE_READING
-                    }
-                    .onFailure { exception ->
-                        val handleErrorMessage = { message: String ->
-                            Logger.e(message)
-                            sideEffect = BookDetailSideEffect.ShowToast(message)
-                        }
+                    bookDetail = detail
+                    seedsStates = seeds.categories.toImmutableList()
+                    readingRecords = records.content.toPersistentList()
 
-                        handleException(
-                            exception = exception,
-                            onError = handleErrorMessage,
-                            onLoginRequired = {
-                                navigator.resetRoot(LoginScreen)
-                            },
-                        )
-                    }
+                    uiState = UiState.Success
+                }
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (e: Throwable) {
+                uiState = UiState.Error(e)
+
+                val handleErrorMessage = { message: String ->
+                    Logger.e(message)
+                    sideEffect = BookDetailSideEffect.ShowToast(message)
+                }
+
+                handleException(
+                    exception = e,
+                    onError = handleErrorMessage,
+                    onLoginRequired = {
+                        navigator.resetRoot(LoginScreen)
+                    },
+                )
             }
         }
 
@@ -125,6 +128,11 @@ class BookDetailPresenter @AssistedInject constructor(
                         isBookUpdateBottomSheetVisible = false
                     }
                     .onFailure { exception ->
+                        postErrorDialog(
+                            errorScope = ErrorScope.BOOK_REGISTER,
+                            exception = exception,
+                        )
+
                         val handleErrorMessage = { message: String ->
                             Logger.e(message)
                             sideEffect = BookDetailSideEffect.ShowToast(message)
@@ -141,13 +149,14 @@ class BookDetailPresenter @AssistedInject constructor(
             }
         }
 
-        fun getReadingRecords(startIndex: Int = START_INDEX) {
+        fun loadMoreReadingRecords(startIndex: Int) {
+            // 초기 페이지 로드는 initialLoad()에서 담당하므로 무시
+            if (startIndex == START_INDEX || isLastPage) {
+                return
+            }
+
             scope.launch {
-                if (startIndex == START_INDEX) {
-                    uiState = UiState.Loading
-                } else {
-                    footerState = FooterState.Loading
-                }
+                footerState = FooterState.Loading
 
                 recordRepository.getReadingRecords(
                     userBookId = screen.userBookId,
@@ -155,36 +164,20 @@ class BookDetailPresenter @AssistedInject constructor(
                     page = startIndex,
                     size = PAGE_SIZE,
                 ).onSuccess { result ->
-                    readingRecords = if (startIndex == START_INDEX) {
-                        result.content.toPersistentList()
-                    } else {
-                        (readingRecords + result.content).toPersistentList()
-                    }
-
+                    readingRecords = (readingRecords + result.content).toPersistentList()
                     currentStartIndex = startIndex
                     isLastPage = result.content.size < PAGE_SIZE
-
-                    if (startIndex == START_INDEX) {
-                        uiState = UiState.Success
-                    } else {
-                        footerState = if (isLastPage) FooterState.End else FooterState.Idle
-                    }
+                    footerState = if (isLastPage) FooterState.End else FooterState.Idle
                 }.onFailure { exception ->
                     Logger.d(exception)
                     val errorMessage = exception.message ?: "알 수 없는 오류가 발생했습니다."
-                    if (startIndex == START_INDEX) {
-                        uiState = UiState.Error(errorMessage)
-                    } else {
-                        footerState = FooterState.Error(errorMessage)
-                    }
+                    footerState = FooterState.Error(errorMessage)
                 }
             }
         }
 
         LaunchedEffect(Unit) {
-            getSeedsStats()
-            getBookDetail()
-            getReadingRecords()
+            initialLoad()
         }
 
         fun handleEvent(event: BookDetailUiEvent) {
@@ -237,7 +230,13 @@ class BookDetailPresenter @AssistedInject constructor(
 
                 is BookDetailUiEvent.OnLoadMore -> {
                     if (uiState != UiState.Loading && footerState !is FooterState.Loading && !isLastPage) {
-                        getReadingRecords(startIndex = currentStartIndex + 1)
+                        loadMoreReadingRecords(startIndex = currentStartIndex + 1)
+                    }
+                }
+
+                is BookDetailUiEvent.OnRetryClick -> {
+                    scope.launch {
+                        initialLoad()
                     }
                 }
             }

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailUi.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailUi.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -40,6 +41,7 @@ import com.ninecraft.booket.core.ui.ReedScaffold
 import com.ninecraft.booket.core.ui.component.InfinityLazyColumn
 import com.ninecraft.booket.core.ui.component.LoadStateFooter
 import com.ninecraft.booket.core.ui.component.ReedBackTopAppBar
+import com.ninecraft.booket.core.ui.component.ReedErrorUi
 import com.ninecraft.booket.feature.detail.R
 import com.ninecraft.booket.feature.detail.book.component.BookItem
 import com.ninecraft.booket.feature.detail.book.component.BookUpdateBottomSheet
@@ -49,6 +51,7 @@ import com.ninecraft.booket.feature.detail.book.component.RecordItem
 import com.ninecraft.booket.feature.detail.book.component.RecordSortBottomSheet
 import com.ninecraft.booket.feature.screens.BookDetailScreen
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.runtime.ui.ui
 import dagger.hilt.android.components.ActivityRetainedComponent
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
@@ -130,141 +133,163 @@ internal fun BookDetailContent(
     modifier: Modifier = Modifier,
     lazyListState: LazyListState = rememberLazyListState(),
 ) {
-    InfinityLazyColumn(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(innerPadding),
-        state = lazyListState,
-        loadMore = {
-            state.eventSink(BookDetailUiEvent.OnLoadMore)
-        },
-    ) {
-        item {
-            ReedBackTopAppBar(
-                title = "",
-                onBackClick = {
-                    state.eventSink(BookDetailUiEvent.OnBackClick)
+    when (state.uiState) {
+        is UiState.Idle -> {}
+        is UiState.Loading -> {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(color = ReedTheme.colors.contentBrand)
+            }
+        }
+
+        is UiState.Success -> {
+            InfinityLazyColumn(
+                modifier = modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                state = lazyListState,
+                loadMore = {
+                    state.eventSink(BookDetailUiEvent.OnLoadMore)
                 },
+            ) {
+                item {
+                    ReedBackTopAppBar(
+                        title = "",
+                        onBackClick = {
+                            state.eventSink(BookDetailUiEvent.OnBackClick)
+                        },
+                    )
+                }
+
+                item {
+                    Column {
+                        BookItem(bookDetail = state.bookDetail)
+                        Spacer(Modifier.height(28.dp))
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = ReedTheme.spacing.spacing5),
+                        ) {
+                            ReedButton(
+                                onClick = {
+                                    state.eventSink(BookDetailUiEvent.OnBookStatusButtonClick)
+                                },
+                                text = stringResource(
+                                    BookStatus.fromValue(state.bookDetail.userBookStatus)?.getDisplayNameRes()
+                                        ?: BookStatus.BEFORE_READING.getDisplayNameRes(),
+                                ),
+                                sizeStyle = largeButtonStyle,
+                                colorStyle = ReedButtonColorStyle.SECONDARY,
+                                modifier = Modifier.widthIn(min = 98.dp),
+                                trailingIcon = {
+                                    Icon(
+                                        imageVector = ImageVector.vectorResource(designR.drawable.ic_chevron_down),
+                                        contentDescription = "Dropdown Icon",
+                                        modifier = Modifier.size(22.dp),
+                                        tint = ReedTheme.colors.contentPrimary,
+                                    )
+                                },
+                            )
+                            Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing2))
+                            ReedButton(
+                                onClick = {
+                                    state.eventSink(BookDetailUiEvent.OnRegisterRecordButtonClick)
+                                },
+                                text = stringResource(R.string.register_book_record),
+                                sizeStyle = largeButtonStyle,
+                                colorStyle = ReedButtonColorStyle.PRIMARY,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                    }
+                }
+
+                item {
+                    if (state.hasEmotionData()) {
+                        CollectedSeeds(seedsStats = state.seedsStats)
+                    } else {
+                        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing10))
+                    }
+
+                    ReedDivider()
+                }
+
+                item {
+                    Column(
+                        modifier = Modifier.padding(horizontal = ReedTheme.spacing.spacing5),
+                    ) {
+                        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing6))
+                        ReadingRecordsHeader(
+                            readingRecords = state.readingRecords,
+                            currentRecordSort = state.currentRecordSort,
+                            onReadingRecordClick = {
+                                state.eventSink(BookDetailUiEvent.OnRecordSortButtonClick)
+                            },
+                        )
+                        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing4))
+                    }
+                }
+
+                if (state.readingRecords.isEmpty()) {
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(324.dp)
+                                .padding(horizontal = ReedTheme.spacing.spacing5),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = stringResource(R.string.records_collection_empty),
+                                color = ReedTheme.colors.contentSecondary,
+                                textAlign = TextAlign.Center,
+                                style = ReedTheme.typography.body1Medium,
+                            )
+                        }
+                    }
+                } else {
+                    items(
+                        count = state.readingRecords.size,
+                        key = { index -> state.readingRecords[index].id },
+                    ) { index ->
+                        val record = state.readingRecords[index]
+                        RecordItem(
+                            quote = record.quote,
+                            emotionTags = record.emotionTags.toImmutableList(),
+                            pageNumber = record.pageNumber,
+                            createdAt = record.createdAt.toFormattedDate(),
+                            modifier = Modifier
+                                .padding(
+                                    start = ReedTheme.spacing.spacing5,
+                                    end = ReedTheme.spacing.spacing5,
+                                    bottom = ReedTheme.spacing.spacing3,
+                                )
+                                .clickable {
+                                    state.eventSink(BookDetailUiEvent.OnRecordItemClick(record.id))
+                                },
+                        )
+                    }
+
+                    item {
+                        LoadStateFooter(
+                            footerState = state.footerState,
+                            onRetryClick = { state.eventSink(BookDetailUiEvent.OnLoadMore) },
+                        )
+                    }
+                }
+            }
+        }
+
+        is UiState.Error -> {
+            ReedErrorUi(
+                exception = state.uiState.exception,
+                onRetryClick = { state.eventSink(BookDetailUiEvent.OnRetryClick) },
             )
         }
-
-        item {
-            Column {
-                BookItem(bookDetail = state.bookDetail)
-                Spacer(Modifier.height(28.dp))
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = ReedTheme.spacing.spacing5),
-                ) {
-                    ReedButton(
-                        onClick = {
-                            state.eventSink(BookDetailUiEvent.OnBookStatusButtonClick)
-                        },
-                        text = stringResource(
-                            BookStatus.fromValue(state.bookDetail.userBookStatus)?.getDisplayNameRes()
-                                ?: BookStatus.BEFORE_READING.getDisplayNameRes(),
-                        ),
-                        sizeStyle = largeButtonStyle,
-                        colorStyle = ReedButtonColorStyle.SECONDARY,
-                        modifier = Modifier.widthIn(min = 98.dp),
-                        trailingIcon = {
-                            Icon(
-                                imageVector = ImageVector.vectorResource(designR.drawable.ic_chevron_down),
-                                contentDescription = "Dropdown Icon",
-                                modifier = Modifier.size(22.dp),
-                                tint = ReedTheme.colors.contentPrimary,
-                            )
-                        },
-                    )
-                    Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing2))
-                    ReedButton(
-                        onClick = {
-                            state.eventSink(BookDetailUiEvent.OnRegisterRecordButtonClick)
-                        },
-                        text = stringResource(R.string.register_book_record),
-                        sizeStyle = largeButtonStyle,
-                        colorStyle = ReedButtonColorStyle.PRIMARY,
-                        modifier = Modifier.weight(1f),
-                    )
-                }
-            }
-        }
-
-        item {
-            if (state.hasEmotionData()) {
-                CollectedSeeds(seedsStats = state.seedsStats)
-            } else {
-                Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing10))
-            }
-
-            ReedDivider()
-        }
-
-        item {
-            Column(
-                modifier = Modifier.padding(horizontal = ReedTheme.spacing.spacing5),
-            ) {
-                Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing6))
-                ReadingRecordsHeader(
-                    readingRecords = state.readingRecords,
-                    currentRecordSort = state.currentRecordSort,
-                    onReadingRecordClick = {
-                        state.eventSink(BookDetailUiEvent.OnRecordSortButtonClick)
-                    },
-                )
-                Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing4))
-            }
-        }
-
-        if (state.readingRecords.isEmpty()) {
-            item {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(324.dp)
-                        .padding(horizontal = ReedTheme.spacing.spacing5),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = stringResource(R.string.records_collection_empty),
-                        color = ReedTheme.colors.contentSecondary,
-                        textAlign = TextAlign.Center,
-                        style = ReedTheme.typography.body1Medium,
-                    )
-                }
-            }
-        } else {
-            items(
-                count = state.readingRecords.size,
-                key = { index -> state.readingRecords[index].id },
-            ) { index ->
-                val record = state.readingRecords[index]
-                RecordItem(
-                    quote = record.quote,
-                    emotionTags = record.emotionTags.toImmutableList(),
-                    pageNumber = record.pageNumber,
-                    createdAt = record.createdAt.toFormattedDate(),
-                    modifier = Modifier
-                        .padding(
-                            start = ReedTheme.spacing.spacing5,
-                            end = ReedTheme.spacing.spacing5,
-                            bottom = ReedTheme.spacing.spacing3,
-                        )
-                        .clickable {
-                            state.eventSink(BookDetailUiEvent.OnRecordItemClick(record.id))
-                        },
-                )
-            }
-
-            item {
-                LoadStateFooter(
-                    footerState = state.footerState,
-                    onRetryClick = { state.eventSink(BookDetailUiEvent.OnLoadMore) },
-                )
-            }
-        }
     }
+
 }
 
 @ComponentPreview
@@ -273,6 +298,7 @@ private fun BookDetailPreview() {
     ReedTheme {
         BookDetailUi(
             state = BookDetailUiState(
+                uiState = UiState.Success,
                 eventSink = {},
             ),
         )

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailUi.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailUi.kt
@@ -51,7 +51,6 @@ import com.ninecraft.booket.feature.detail.book.component.RecordItem
 import com.ninecraft.booket.feature.detail.book.component.RecordSortBottomSheet
 import com.ninecraft.booket.feature.screens.BookDetailScreen
 import com.slack.circuit.codegen.annotations.CircuitInject
-import com.slack.circuit.runtime.ui.ui
 import dagger.hilt.android.components.ActivityRetainedComponent
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
@@ -289,7 +288,6 @@ internal fun BookDetailContent(
             )
         }
     }
-
 }
 
 @ComponentPreview

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailUiState.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/BookDetailUiState.kt
@@ -17,7 +17,7 @@ sealed interface UiState {
     data object Idle : UiState
     data object Loading : UiState
     data object Success : UiState
-    data class Error(val message: String) : UiState
+    data class Error(val exception: Throwable) : UiState
 }
 
 data class BookDetailUiState(
@@ -63,6 +63,7 @@ sealed interface BookDetailUiEvent : CircuitUiEvent {
     data class OnRecordSortItemSelected(val sortType: RecordSort) : BookDetailUiEvent
     data class OnRecordItemClick(val recordId: String) : BookDetailUiEvent
     data object OnLoadMore : BookDetailUiEvent
+    data object OnRetryClick : BookDetailUiEvent
 }
 
 enum class RecordSort(val value: String) {

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/component/RecordItem.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/book/component/RecordItem.kt
@@ -89,7 +89,7 @@ internal fun RecordItem(
     }
 }
 
-private fun getEmotionImageResourceByDisplayName(displayName: String): Int {
+fun getEmotionImageResourceByDisplayName(displayName: String): Int {
     return when (displayName) {
         "따뜻함" -> R.drawable.img_warm
         "즐거움" -> R.drawable.img_joy

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/RecordDetailPresenter.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/RecordDetailPresenter.kt
@@ -41,8 +41,8 @@ class RecordDetailPresenter @AssistedInject constructor(
 
                 repository.getRecordDetail(readingRecordId = readingRecordId)
                     .onSuccess { result ->
-                        uiState = UiState.Success
                         recordDetailInfo = result
+                        uiState = UiState.Success
                     }
                     .onFailure { exception ->
                         uiState = UiState.Error(exception)

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/RecordDetailPresenter.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/RecordDetailPresenter.kt
@@ -31,17 +31,21 @@ class RecordDetailPresenter @AssistedInject constructor(
     @Composable
     override fun present(): RecordDetailUiState {
         val scope = rememberCoroutineScope()
-
+        var uiState by rememberRetained { mutableStateOf<UiState>(UiState.Idle) }
         var recordDetailInfo by rememberRetained { mutableStateOf(RecordDetailModel()) }
         var sideEffect by rememberRetained { mutableStateOf<RecordDetailSideEffect?>(null) }
 
         fun getRecordDetail(readingRecordId: String) {
             scope.launch {
+                uiState = UiState.Loading
+
                 repository.getRecordDetail(readingRecordId = readingRecordId)
                     .onSuccess { result ->
+                        uiState = UiState.Success
                         recordDetailInfo = result
                     }
                     .onFailure { exception ->
+                        uiState = UiState.Error(exception)
                         val handleErrorMessage = { message: String ->
                             Logger.e(message)
                             sideEffect = RecordDetailSideEffect.ShowToast(message)
@@ -63,6 +67,10 @@ class RecordDetailPresenter @AssistedInject constructor(
                 RecordDetailUiEvent.OnCloseClicked -> {
                     navigator.pop()
                 }
+
+                RecordDetailUiEvent.onRetryClick -> {
+                    getRecordDetail(screen.recordId)
+                }
             }
         }
 
@@ -71,6 +79,7 @@ class RecordDetailPresenter @AssistedInject constructor(
         }
 
         return RecordDetailUiState(
+            uiState = uiState,
             recordDetailInfo = recordDetailInfo,
             sideEffect = sideEffect,
             eventSink = ::handleEvent,

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/RecordDetailUi.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/RecordDetailUi.kt
@@ -1,5 +1,6 @@
 package com.ninecraft.booket.feature.detail.record
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
@@ -29,12 +31,14 @@ import com.ninecraft.booket.core.designsystem.theme.ReedTheme
 import com.ninecraft.booket.core.designsystem.theme.White
 import com.ninecraft.booket.core.model.RecordDetailModel
 import com.ninecraft.booket.core.ui.ReedScaffold
+import com.ninecraft.booket.core.ui.component.ReedErrorUi
 import com.ninecraft.booket.core.ui.component.ReedTopAppBar
 import com.ninecraft.booket.feature.detail.R
 import com.ninecraft.booket.feature.detail.record.component.QuoteBox
 import com.ninecraft.booket.feature.detail.record.component.ReviewBox
 import com.ninecraft.booket.feature.screens.RecordDetailScreen
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.runtime.ui.ui
 import dagger.hilt.android.components.ActivityRetainedComponent
 import com.ninecraft.booket.core.designsystem.R as designR
 
@@ -78,98 +82,120 @@ private fun ReviewDetailContent(
                 state.eventSink(RecordDetailUiEvent.OnCloseClicked)
             },
         )
-        Row(
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(
-                    horizontal = ReedTheme.spacing.spacing5,
-                    vertical = ReedTheme.spacing.spacing4,
-                ),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            NetworkImage(
-                imageUrl = state.recordDetailInfo.bookCoverImageUrl,
-                contentDescription = "Book CoverImage",
-                modifier = Modifier
-                    .padding(end = ReedTheme.spacing.spacing4)
-                    .width(46.dp)
-                    .height(68.dp)
-                    .clip(RoundedCornerShape(size = ReedTheme.radius.xs)),
-                placeholder = painterResource(designR.drawable.ic_placeholder),
-            )
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = state.recordDetailInfo.bookTitle,
-                    color = ReedTheme.colors.contentPrimary,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 1,
-                    style = ReedTheme.typography.body1SemiBold,
-                )
-                Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing1))
-                BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-                    val authorMaxWidth = maxWidth * 0.7f
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = state.recordDetailInfo.author,
-                            color = ReedTheme.colors.contentTertiary,
-                            overflow = TextOverflow.Ellipsis,
-                            maxLines = 1,
-                            style = ReedTheme.typography.label1Medium,
-                            modifier = Modifier.widthIn(max = authorMaxWidth),
-                        )
-                        Spacer(Modifier.width(ReedTheme.spacing.spacing1))
-                        VerticalDivider(
-                            modifier = Modifier.height(14.dp),
-                            thickness = 1.dp,
-                            color = ReedTheme.colors.contentTertiary,
-                        )
-                        Spacer(Modifier.width(ReedTheme.spacing.spacing1))
-                        Text(
-                            text = state.recordDetailInfo.bookPublisher,
-                            color = ReedTheme.colors.contentTertiary,
-                            overflow = TextOverflow.Ellipsis,
-                            maxLines = 1,
-                            style = ReedTheme.typography.label1Medium,
-                            modifier = Modifier.weight(1f, fill = false),
-                        )
-                    }
+        when (state.uiState) {
+            is UiState.Idle -> {}
+            is UiState.Loading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(color = ReedTheme.colors.contentBrand)
                 }
             }
-        }
-        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
-        ReedDivider()
-        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing6))
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = ReedTheme.spacing.spacing5),
-        ) {
-            Text(
-                text = stringResource(R.string.review_detail_quote_label),
-                color = ReedTheme.colors.contentPrimary,
-                style = ReedTheme.typography.body1Medium,
-            )
-            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
-            QuoteBox(
-                quote = state.recordDetailInfo.quote,
-                page = state.recordDetailInfo.pageNumber,
-            )
-            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing6))
-            Text(
-                text = stringResource(R.string.review_detail_impression_label),
-                color = ReedTheme.colors.contentPrimary,
-                style = ReedTheme.typography.body1Medium,
-            )
-            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
-            ReviewBox(
-                emotion = state.recordDetailInfo.emotionTags.getOrNull(0) ?: "",
-                createdAt = state.recordDetailInfo.createdAt,
-                review = state.recordDetailInfo.review,
-            )
+
+            is UiState.Success -> {
+                Row(
+                    modifier = modifier
+                        .fillMaxWidth()
+                        .padding(
+                            horizontal = ReedTheme.spacing.spacing5,
+                            vertical = ReedTheme.spacing.spacing4,
+                        ),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    NetworkImage(
+                        imageUrl = state.recordDetailInfo.bookCoverImageUrl,
+                        contentDescription = "Book CoverImage",
+                        modifier = Modifier
+                            .padding(end = ReedTheme.spacing.spacing4)
+                            .width(46.dp)
+                            .height(68.dp)
+                            .clip(RoundedCornerShape(size = ReedTheme.radius.xs)),
+                        placeholder = painterResource(designR.drawable.ic_placeholder),
+                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = state.recordDetailInfo.bookTitle,
+                            color = ReedTheme.colors.contentPrimary,
+                            overflow = TextOverflow.Ellipsis,
+                            maxLines = 1,
+                            style = ReedTheme.typography.body1SemiBold,
+                        )
+                        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing1))
+                        BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                            val authorMaxWidth = maxWidth * 0.7f
+
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = state.recordDetailInfo.author,
+                                    color = ReedTheme.colors.contentTertiary,
+                                    overflow = TextOverflow.Ellipsis,
+                                    maxLines = 1,
+                                    style = ReedTheme.typography.label1Medium,
+                                    modifier = Modifier.widthIn(max = authorMaxWidth),
+                                )
+                                Spacer(Modifier.width(ReedTheme.spacing.spacing1))
+                                VerticalDivider(
+                                    modifier = Modifier.height(14.dp),
+                                    thickness = 1.dp,
+                                    color = ReedTheme.colors.contentTertiary,
+                                )
+                                Spacer(Modifier.width(ReedTheme.spacing.spacing1))
+                                Text(
+                                    text = state.recordDetailInfo.bookPublisher,
+                                    color = ReedTheme.colors.contentTertiary,
+                                    overflow = TextOverflow.Ellipsis,
+                                    maxLines = 1,
+                                    style = ReedTheme.typography.label1Medium,
+                                    modifier = Modifier.weight(1f, fill = false),
+                                )
+                            }
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
+                ReedDivider()
+                Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing6))
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = ReedTheme.spacing.spacing5),
+                ) {
+                    Text(
+                        text = stringResource(R.string.review_detail_quote_label),
+                        color = ReedTheme.colors.contentPrimary,
+                        style = ReedTheme.typography.body1Medium,
+                    )
+                    Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
+                    QuoteBox(
+                        quote = state.recordDetailInfo.quote,
+                        page = state.recordDetailInfo.pageNumber,
+                    )
+                    Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing6))
+                    Text(
+                        text = stringResource(R.string.review_detail_impression_label),
+                        color = ReedTheme.colors.contentPrimary,
+                        style = ReedTheme.typography.body1Medium,
+                    )
+                    Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
+                    ReviewBox(
+                        emotion = state.recordDetailInfo.emotionTags.getOrNull(0) ?: "",
+                        createdAt = state.recordDetailInfo.createdAt,
+                        review = state.recordDetailInfo.review,
+                    )
+                }
+            }
+
+            is UiState.Error -> {
+                ReedErrorUi(
+                    exception = state.uiState.exception,
+                    onRetryClick = { },
+                )
+            }
+
         }
     }
 }
@@ -180,6 +206,7 @@ private fun ReviewDetailPreview() {
     ReedTheme {
         RecordDetailUi(
             state = RecordDetailUiState(
+                uiState = UiState.Success,
                 recordDetailInfo = RecordDetailModel(
                     id = "",
                     userBookId = "",

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/RecordDetailUi.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/RecordDetailUi.kt
@@ -38,7 +38,6 @@ import com.ninecraft.booket.feature.detail.record.component.QuoteBox
 import com.ninecraft.booket.feature.detail.record.component.ReviewBox
 import com.ninecraft.booket.feature.screens.RecordDetailScreen
 import com.slack.circuit.codegen.annotations.CircuitInject
-import com.slack.circuit.runtime.ui.ui
 import dagger.hilt.android.components.ActivityRetainedComponent
 import com.ninecraft.booket.core.designsystem.R as designR
 
@@ -195,7 +194,6 @@ private fun ReviewDetailContent(
                     onRetryClick = { },
                 )
             }
-
         }
     }
 }

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/RecordDetailUiState.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/RecordDetailUiState.kt
@@ -30,5 +30,5 @@ sealed interface RecordDetailSideEffect {
 
 sealed interface RecordDetailUiEvent : CircuitUiEvent {
     data object OnCloseClicked : RecordDetailUiEvent
-    data object onRetryClick: RecordDetailUiEvent
+    data object onRetryClick : RecordDetailUiEvent
 }

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/RecordDetailUiState.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/RecordDetailUiState.kt
@@ -6,7 +6,15 @@ import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import java.util.UUID
 
+sealed interface UiState {
+    data object Idle : UiState
+    data object Loading : UiState
+    data object Success : UiState
+    data class Error(val exception: Throwable) : UiState
+}
+
 data class RecordDetailUiState(
+    val uiState: UiState = UiState.Idle,
     val recordDetailInfo: RecordDetailModel = RecordDetailModel(),
     val sideEffect: RecordDetailSideEffect? = null,
     val eventSink: (RecordDetailUiEvent) -> Unit,
@@ -22,4 +30,5 @@ sealed interface RecordDetailSideEffect {
 
 sealed interface RecordDetailUiEvent : CircuitUiEvent {
     data object OnCloseClicked : RecordDetailUiEvent
+    data object onRetryClick: RecordDetailUiEvent
 }

--- a/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/component/ReviewBox.kt
+++ b/feature/detail/src/main/kotlin/com/ninecraft/booket/feature/detail/record/component/ReviewBox.kt
@@ -1,5 +1,6 @@
 package com.ninecraft.booket.feature.detail.record.component
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,8 +18,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
 import com.ninecraft.booket.core.designsystem.ComponentPreview
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
+import com.ninecraft.booket.feature.detail.book.component.getEmotionImageResourceByDisplayName
 
 @Composable
 fun ReviewBox(
@@ -44,14 +47,12 @@ fun ReviewBox(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Box(
+                Image(
+                    painter = painterResource(getEmotionImageResourceByDisplayName(emotion)),
+                    contentDescription = "Emotion Graphic",
                     modifier = Modifier
                         .size(ReedTheme.spacing.spacing10)
-                        .background(
-                            color = ReedTheme.colors.bgTertiary,
-                            shape = CircleShape,
-                        )
-                        .clip(shape = CircleShape),
+                        .clip(CircleShape),
                 )
                 Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing2))
                 Text(

--- a/feature/home/src/main/kotlin/com/ninecraft/booket/feature/home/HomePresenter.kt
+++ b/feature/home/src/main/kotlin/com/ninecraft/booket/feature/home/HomePresenter.kt
@@ -35,7 +35,6 @@ class HomePresenter @AssistedInject constructor(
         val scope = rememberCoroutineScope()
 
         var uiState by rememberRetained { mutableStateOf<UiState>(UiState.Idle) }
-        var sideEffect by rememberRetained { mutableStateOf<HomeSideEffect?>(null) }
         var recentBooks by rememberRetained { mutableStateOf(persistentListOf<RecentBookModel>()) }
 
         fun loadHomeContent() {

--- a/feature/home/src/main/kotlin/com/ninecraft/booket/feature/home/HomePresenter.kt
+++ b/feature/home/src/main/kotlin/com/ninecraft/booket/feature/home/HomePresenter.kt
@@ -39,7 +39,7 @@ class HomePresenter @AssistedInject constructor(
 
         fun loadHomeContent() {
             scope.launch {
-                if (uiState == UiState.Idle) {
+                if (uiState is UiState.Idle || uiState is UiState.Error) {
                     uiState = UiState.Loading
                 }
 

--- a/feature/home/src/main/kotlin/com/ninecraft/booket/feature/home/HomePresenter.kt
+++ b/feature/home/src/main/kotlin/com/ninecraft/booket/feature/home/HomePresenter.kt
@@ -6,16 +6,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import com.ninecraft.booket.core.common.utils.handleException
 import com.ninecraft.booket.core.data.api.repository.BookRepository
 import com.ninecraft.booket.core.model.RecentBookModel
 import com.ninecraft.booket.feature.screens.BookDetailScreen
 import com.ninecraft.booket.feature.screens.HomeScreen
-import com.ninecraft.booket.feature.screens.LoginScreen
 import com.ninecraft.booket.feature.screens.RecordScreen
 import com.ninecraft.booket.feature.screens.SearchScreen
 import com.ninecraft.booket.feature.screens.SettingsScreen
-import com.orhanobut.logger.Logger
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.Navigator
@@ -43,7 +40,7 @@ class HomePresenter @AssistedInject constructor(
 
         fun loadHomeContent() {
             scope.launch {
-                if (uiState == UiState.Idle || uiState == UiState.Error) {
+                if (uiState == UiState.Idle) {
                     uiState = UiState.Loading
                 }
 
@@ -52,19 +49,7 @@ class HomePresenter @AssistedInject constructor(
                         uiState = UiState.Success
                         recentBooks = result.recentBooks.toPersistentList()
                     }.onFailure { exception ->
-                        uiState = UiState.Error
-                        val handleErrorMessage = { message: String ->
-                            Logger.e(message)
-                            sideEffect = HomeSideEffect.ShowToast(message)
-                        }
-
-                        handleException(
-                            exception = exception,
-                            onError = handleErrorMessage,
-                            onLoginRequired = {
-                                navigator.resetRoot(LoginScreen)
-                            },
-                        )
+                        uiState = UiState.Error(exception)
                     }
             }
         }

--- a/feature/home/src/main/kotlin/com/ninecraft/booket/feature/home/HomeUi.kt
+++ b/feature/home/src/main/kotlin/com/ninecraft/booket/feature/home/HomeUi.kt
@@ -24,12 +24,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.ninecraft.booket.core.designsystem.DevicePreview
-import com.ninecraft.booket.core.designsystem.component.button.ReedButton
-import com.ninecraft.booket.core.designsystem.component.button.ReedButtonColorStyle
-import com.ninecraft.booket.core.designsystem.component.button.largeButtonStyle
 import com.ninecraft.booket.core.designsystem.theme.HomeBg
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
 import com.ninecraft.booket.core.ui.ReedScaffold
+import com.ninecraft.booket.core.ui.component.ReedErrorUi
 import com.ninecraft.booket.feature.home.component.BookCard
 import com.ninecraft.booket.feature.home.component.EmptyBookCard
 import com.ninecraft.booket.feature.home.component.HomeBanner
@@ -170,29 +168,10 @@ internal fun HomeContent(
             }
 
             is UiState.Error -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Text(
-                            text = stringResource(R.string.home_error_title),
-                            color = ReedTheme.colors.contentPrimary,
-                            style = ReedTheme.typography.headline1SemiBold,
-                        )
-                        Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
-                        ReedButton(
-                            onClick = {
-                                state.eventSink(HomeUiEvent.OnRetryClick)
-                            },
-                            sizeStyle = largeButtonStyle,
-                            colorStyle = ReedButtonColorStyle.PRIMARY,
-                            text = stringResource(R.string.home_retry),
-                        )
-                    }
-                }
+                ReedErrorUi(
+                    exception = state.uiState.exception,
+                    onRetryClick = { state.eventSink(HomeUiEvent.OnRetryClick) },
+                )
             }
         }
     }

--- a/feature/home/src/main/kotlin/com/ninecraft/booket/feature/home/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/ninecraft/booket/feature/home/HomeUiState.kt
@@ -13,7 +13,7 @@ sealed interface UiState {
     data object Idle : UiState
     data object Loading : UiState
     data object Success : UiState
-    data object Error : UiState
+    data class Error(val exception: Throwable) : UiState
 }
 
 data class HomeUiState(

--- a/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryPresenter.kt
+++ b/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryPresenter.kt
@@ -91,7 +91,7 @@ class LibraryPresenter @AssistedInject constructor(
                         Logger.d(exception)
                         val errorMessage = exception.message ?: "알 수 없는 오류가 발생했습니다."
                         if (page == START_INDEX) {
-                            uiState = UiState.Error(errorMessage)
+                            uiState = UiState.Error(exception)
                         } else {
                             footerState = FooterState.Error(errorMessage)
                         }

--- a/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryPresenter.kt
+++ b/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryPresenter.kt
@@ -114,6 +114,10 @@ class LibraryPresenter @AssistedInject constructor(
                 }
 
                 is LibraryUiEvent.OnFilterClick -> {
+                    if (currentFilter == event.filterOption) {
+                        return
+                    }
+
                     currentFilter = event.filterOption
                     filterLibraryBooks(status = currentFilter.getApiValue(), page = START_INDEX, size = PAGE_SIZE)
                 }
@@ -148,13 +152,11 @@ class LibraryPresenter @AssistedInject constructor(
         }
 
         LaunchedEffect(Unit) {
-            if (uiState == UiState.Idle || uiState is UiState.Error) {
-                filterLibraryBooks(
-                    status = currentFilter.getApiValue(),
-                    page = START_INDEX,
-                    size = PAGE_SIZE,
-                )
-            }
+            filterLibraryBooks(
+                status = currentFilter.getApiValue(),
+                page = START_INDEX,
+                size = PAGE_SIZE,
+            )
         }
 
         return LibraryUiState(

--- a/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryUi.kt
+++ b/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryUi.kt
@@ -18,14 +18,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.ninecraft.booket.core.designsystem.DevicePreview
-import com.ninecraft.booket.core.designsystem.component.button.ReedButton
-import com.ninecraft.booket.core.designsystem.component.button.ReedButtonColorStyle
-import com.ninecraft.booket.core.designsystem.component.button.largeButtonStyle
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
 import com.ninecraft.booket.core.model.LibraryBookSummaryModel
 import com.ninecraft.booket.core.ui.ReedScaffold
 import com.ninecraft.booket.core.ui.component.InfinityLazyColumn
 import com.ninecraft.booket.core.ui.component.LoadStateFooter
+import com.ninecraft.booket.core.ui.component.ReedErrorUi
 import com.ninecraft.booket.feature.library.component.FilterChipGroup
 import com.ninecraft.booket.feature.library.component.LibraryBookItem
 import com.ninecraft.booket.feature.library.component.LibraryHeader
@@ -149,7 +147,10 @@ internal fun LibraryContent(
             }
 
             is UiState.Error -> {
-                ErrorResult(state = state, errorMessage = state.uiState.message)
+                ReedErrorUi(
+                    exception = state.uiState.exception,
+                    onRetryClick = { state.eventSink(LibraryUiEvent.OnRetryClick) },
+                )
             }
         }
     }
@@ -174,39 +175,6 @@ private fun EmptyResult() {
                 text = stringResource(R.string.library_empty_book_description),
                 color = ReedTheme.colors.contentSecondary,
                 style = ReedTheme.typography.body1Medium,
-            )
-        }
-    }
-}
-
-@Composable
-private fun ErrorResult(state: LibraryUiState, errorMessage: String) {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Text(
-                text = stringResource(R.string.library_error_title),
-                color = ReedTheme.colors.contentPrimary,
-                style = ReedTheme.typography.headline1SemiBold,
-            )
-            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
-            Text(
-                text = errorMessage,
-                color = ReedTheme.colors.contentSecondary,
-                style = ReedTheme.typography.body1Medium,
-            )
-            Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing2))
-            ReedButton(
-                onClick = {
-                    state.eventSink(LibraryUiEvent.OnRetryClick)
-                },
-                sizeStyle = largeButtonStyle,
-                colorStyle = ReedButtonColorStyle.PRIMARY,
-                text = stringResource(R.string.library_retry),
             )
         }
     }

--- a/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryUiState.kt
+++ b/feature/library/src/main/kotlin/com/ninecraft/booket/feature/library/LibraryUiState.kt
@@ -14,7 +14,7 @@ sealed interface UiState {
     data object Idle : UiState
     data object Loading : UiState
     data object Success : UiState
-    data class Error(val message: String) : UiState
+    data class Error(val exception: Throwable) : UiState
 }
 
 data class LibraryUiState(

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -8,6 +8,4 @@
     <string name="library_filter_completed">완독</string>
     <string name="library_empty_book_title">아직 등록된 책이 없어요</string>
     <string name="library_empty_book_description">도서 등록 후 나만의 아카이브를 만들어보세요</string>
-    <string name="library_error_title">책 정보를 가져오는데 실패했어요</string>
-    <string name="library_retry">다시 시도</string>
 </resources>

--- a/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/MainActivity.kt
+++ b/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/MainActivity.kt
@@ -75,6 +75,9 @@ class MainActivity : ComponentActivity() {
                             spec.action()
                             dialogSpec.value = null
                         },
+                        onDismissRequest = {
+                            dialogSpec.value = null
+                        },
                     )
                 }
 

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
@@ -10,7 +10,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.TextRange
+import com.ninecraft.booket.core.common.constants.ErrorScope
 import com.ninecraft.booket.core.common.utils.handleException
+import com.ninecraft.booket.core.common.utils.postErrorDialog
 import com.ninecraft.booket.core.data.api.repository.RecordRepository
 import com.ninecraft.booket.core.designsystem.EmotionTag
 import com.ninecraft.booket.core.designsystem.RecordStep
@@ -79,9 +81,11 @@ class RecordRegisterPresenter @AssistedInject constructor(
                     RecordStep.QUOTE -> {
                         recordPageState.text.isNotEmpty() && recordSentenceState.text.isNotEmpty() && !isPageError
                     }
+
                     RecordStep.EMOTION -> {
                         selectedEmotion != null
                     }
+
                     RecordStep.IMPRESSION -> {
                         impressionState.text.isNotEmpty()
                     }
@@ -114,6 +118,11 @@ class RecordRegisterPresenter @AssistedInject constructor(
                     savedRecordId = result.id
                     isRecordSavedDialogVisible = true
                 }.onFailure { exception ->
+                    postErrorDialog(
+                        errorScope = ErrorScope.RECORD_REGISTER,
+                        exception = exception,
+                    )
+
                     val handleErrorMessage = { message: String ->
                         Logger.e(message)
                         sideEffect = RecordRegisterSideEffect.ShowToast(message)

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchPresenter.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchPresenter.kt
@@ -90,7 +90,7 @@ class BookSearchPresenter @AssistedInject constructor(
                         Logger.d(exception)
                         val errorMessage = exception.message ?: "알 수 없는 오류가 발생했습니다."
                         if (startIndex == START_INDEX) {
-                            uiState = UiState.Error(errorMessage)
+                            uiState = UiState.Error(exception)
                         } else {
                             footerState = FooterState.Error(errorMessage)
                         }

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchPresenter.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchPresenter.kt
@@ -9,7 +9,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import com.ninecraft.booket.core.common.constants.BookStatus
+import com.ninecraft.booket.core.common.constants.ErrorScope
 import com.ninecraft.booket.core.common.utils.handleException
+import com.ninecraft.booket.core.common.utils.postErrorDialog
 import com.ninecraft.booket.core.data.api.repository.BookRepository
 import com.ninecraft.booket.core.model.BookSearchModel
 import com.ninecraft.booket.core.model.BookSummaryModel
@@ -115,6 +117,11 @@ class BookSearchPresenter @AssistedInject constructor(
                         isBookRegisterSuccessBottomSheetVisible = true
                     }
                     .onFailure { exception ->
+                        postErrorDialog(
+                            errorScope = ErrorScope.BOOK_REGISTER,
+                            exception = exception,
+                        )
+
                         val handleErrorMessage = { message: String ->
                             Logger.e(message)
                             sideEffect = BookSearchSideEffect.ShowToast(message)

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUi.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUi.kt
@@ -1,7 +1,6 @@
 package com.ninecraft.booket.feature.search.book
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -33,6 +31,7 @@ import com.ninecraft.booket.core.ui.ReedScaffold
 import com.ninecraft.booket.core.ui.component.InfinityLazyColumn
 import com.ninecraft.booket.core.ui.component.LoadStateFooter
 import com.ninecraft.booket.core.ui.component.ReedBackTopAppBar
+import com.ninecraft.booket.core.ui.component.ReedErrorUi
 import com.ninecraft.booket.feature.screens.SearchScreen
 import com.ninecraft.booket.feature.search.R
 import com.ninecraft.booket.feature.search.book.component.BookItem
@@ -125,22 +124,10 @@ internal fun SearchContent(
             }
 
             is UiState.Error -> {
-                Column(
-                    modifier = Modifier.fillMaxSize(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center,
-                ) {
-                    Text(
-                        text = state.uiState.message,
-                        style = ReedTheme.typography.body1Regular,
-                    )
-                    Button(
-                        onClick = { state.eventSink(BookSearchUiEvent.OnRetryClick) },
-                        modifier = Modifier.padding(top = ReedTheme.spacing.spacing3),
-                    ) {
-                        Text(text = stringResource(R.string.retry))
-                    }
-                }
+                ReedErrorUi(
+                    exception = state.uiState.exception,
+                    onRetryClick = { state.eventSink(BookSearchUiEvent.OnRetryClick) },
+                )
             }
 
             is UiState.Idle -> {

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUiState.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUiState.kt
@@ -16,7 +16,7 @@ sealed interface UiState {
     data object Idle : UiState
     data object Loading : UiState
     data object Success : UiState
-    data class Error(val message: String) : UiState
+    data class Error(val exception: Throwable) : UiState
 }
 
 data class BookSearchUiState(

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/library/LibrarySearchPresenter.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/library/LibrarySearchPresenter.kt
@@ -82,7 +82,7 @@ class LibrarySearchPresenter @AssistedInject constructor(
                     .onFailure { exception ->
                         val errorMessage = exception.message ?: "알 수 없는 오류가 발생했습니다."
                         if (page == START_INDEX) {
-                            uiState = UiState.Error(errorMessage)
+                            uiState = UiState.Error(exception)
                         } else {
                             footerState = FooterState.Error(errorMessage)
                         }

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/library/LibrarySearchUi.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/library/LibrarySearchUi.kt
@@ -1,6 +1,5 @@
 package com.ninecraft.booket.feature.search.library
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -10,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
@@ -28,6 +26,7 @@ import com.ninecraft.booket.core.ui.ReedScaffold
 import com.ninecraft.booket.core.ui.component.InfinityLazyColumn
 import com.ninecraft.booket.core.ui.component.LoadStateFooter
 import com.ninecraft.booket.core.ui.component.ReedBackTopAppBar
+import com.ninecraft.booket.core.ui.component.ReedErrorUi
 import com.ninecraft.booket.feature.screens.LibrarySearchScreen
 import com.ninecraft.booket.feature.search.R
 import com.ninecraft.booket.feature.search.common.component.RecentSearchTitle
@@ -105,22 +104,10 @@ internal fun LibrarySearchContent(
             }
 
             is UiState.Error -> {
-                Column(
-                    modifier = Modifier.fillMaxSize(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center,
-                ) {
-                    Text(
-                        text = state.uiState.message,
-                        style = ReedTheme.typography.body1Regular,
-                    )
-                    Button(
-                        onClick = { state.eventSink(LibrarySearchUiEvent.OnRetryClick) },
-                        modifier = Modifier.padding(top = ReedTheme.spacing.spacing3),
-                    ) {
-                        Text(text = stringResource(R.string.retry))
-                    }
-                }
+                ReedErrorUi(
+                    exception = state.uiState.exception,
+                    onRetryClick = { state.eventSink(LibrarySearchUiEvent.OnRetryClick) },
+                )
             }
 
             is UiState.Idle -> {

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/library/LibrarySearchUiState.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/library/LibrarySearchUiState.kt
@@ -13,7 +13,7 @@ sealed interface UiState {
     data object Idle : UiState
     data object Loading : UiState
     data object Success : UiState
-    data class Error(val message: String) : UiState
+    data class Error(val exception: Throwable) : UiState
 }
 
 data class LibrarySearchUiState(

--- a/feature/search/src/main/res/values/strings.xml
+++ b/feature/search/src/main/res/values/strings.xml
@@ -4,7 +4,6 @@
     <string name="search_result_prefix">총&#160;</string>
     <string name="search_result_suffix">개</string>
     <string name="recent_search">최근 검색어</string>
-    <string name="retry">다시 시도</string>
     <string name="error_message">오류가 발생했습니다</string>
     <string name="empty_results">검색어와 일치하는 도서가 없습니다</string>
     <string name="book_register_title">등록 옵션</string>


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #117 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- core:ui 에 `ReedErrorUi`로 화면별 에러 처리
- EventBus를 활용하여 다이얼로그 띄우는 에러 전역 처리
- 도서 상세 화면에서 초기 로드를 async로 구현

## 🧪 테스트 내역
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
### ✅ 전체 화면 에러 (화면에 데이터를 불러와 렌더링 해야하는 경우)
- `네트워크 에러 문구` : 네트워크 연결이 불안정합니다. 인터넷 연결을 확인해주세요
- `그 외 서버 에러 문구` : 알 수 없는 문제가 발생했어요. 다시 시도해주세요

| 홈 | 내서재 | 도서 검색 / 내서재 검색 |
|:--:|:--:|:--:|
| <img width="300" alt="Reed_홈_에러" src="https://github.com/user-attachments/assets/f1616aae-0ae7-4fbd-92ee-f33940e2a5ef" /> | <img width="300" alt="Reed_내서재_에러" src="https://github.com/user-attachments/assets/f18a0230-8a74-4259-9a25-5f6b7de70205" /> | <img width="300" alt="Reed_검색_에러" src="https://github.com/user-attachments/assets/128a2632-5e90-456f-9d92-ff407c8d8aa7" /> | 

| 도서 상세 | 기록 상세 |
|:--:|:--:|
| <img width="300" alt="Reed_도서상세_에러" src="https://github.com/user-attachments/assets/549f0548-b0d3-49c2-b6fa-b643834a9022" /> | <img width="300" alt="Reed_기록상세_에러" src="https://github.com/user-attachments/assets/1a178985-4c7b-4e9c-aba5-5c3eb2212dfe" /> |

### ✅ 에러 다이얼로그 (이미 화면을 보고 있는 상태에서 요청이 있는 경우)
- `네트워크 에러 문구` : 네트워크 연결이 불안정합니다. 인터넷 연결을 확인해주세요
- `그 외 서버 에러 문구` : 상황별 상이함. ErrorScope로 Dialog message 분기(아래 코드 참고)
- **현재 전역 다이얼로그가 적용된 부분 -> 도서등록, 기록 저장**

| 도서 등록 네트워크 에러 | 기록 저장 서버 에러 |
|:--:|:--:|
| <img width="300" alt="Reed_도서등록_에러" src="https://github.com/user-attachments/assets/83ed4fde-4840-46c5-8e40-1a84030be937" /> | <img width="300" alt="Reed_기록저장실패_서버에러" src="https://github.com/user-attachments/assets/f0e32a5a-bd4e-4b33-bed1-a822ebd0fe72" /> |

- 상황별 message를 대응하기 위해 ErrorScope 설정 
- RootView인 MainActivity에서 전역 에러 이벤트 collect  -> 다이얼로그 띄우기

```kotlin
private fun buildDialog(
    scope: ErrorScope,
    exception: Throwable,
    action: () -> Unit,
): ErrorDialogSpec {
    val message = when {
        exception.isNetworkError() -> {
            "네트워크 연결이 불안정합니다.\n인터넷 연결을 확인해주세요"
        }
        exception is HttpException -> {
            when (scope) {
                ErrorScope.GLOBAL -> {
                    "알 수 없는 문제가 발생했어요.\n다시 시도해주세요"
                }

                ErrorScope.LOGIN -> {
                    "예기치 않은 오류가 발생했습니다.\n다시 로그인 해주세요."
                }

                ErrorScope.BOOK_REGISTER -> {
                    "도서 등록 중 오류가 발생했어요.\n다시 시도해주세요"
                }

                ErrorScope.RECORD_REGISTER -> {
                    "기록 저장에 실패했어요.\n다시 시도해주세요"
                }
            }
        }
        else -> {
            "알 수 없는 문제가 발생했어요.\n다시 시도해주세요"
        }
    }

    return ErrorDialogSpec(message = message, buttonLabel ="확인" , action = action)
}
```

## 💬 추가 설명 or 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
## 📌 For PM
### 현재 에러 UI를 다이얼로그로만 보여주는 것에 대해,
### 1. 화면 렌더링 단계의 에러
- **화면에 데이터를 렌더링 하는 시점에서 오류가 발생하면, 전체 화면을 덮는 에러 UI를 노출하는게 적절하다고 생각합니다.**
- `이유`:
  - 다이얼로그에서 다시 시도 버튼만 제공하면 해당 문제가 해결되기 전까지는 다른 화면 탐색이 불가능합니다
  - 확인 버튼을 제공하여 다이얼로그를 닫을 시에도 에러 대응이 되지 않은 화면이 사용자에게 그대로 노출됩니다 (버그로 인식)
  - 현재 당근마켓, 오늘의집, 쿠팡 모두 에러 화면으로 덮는 전략을 사용하고 있습니다

### 2. 화면 진입 이후 추가 데이터 요청 시 발생하는 에러 (로그인, 도서 등록, 기록 등록 등)
- 예: 로그인, 도서 등록, 기록 저장 등
- **이 경우 다이얼로그를 띄우는 것이 적절하나, 꼭 다이얼로그를 띄워야 하는지는 검토가 필요합니다.**
- `이유`:
  - 다이얼로그는 사용자의 주의를 강하게 끌고 액션을 강제하는 UI입니다.
  - 단순 알림이나 확인만 필요한 경우, 스낵바나 토스트로 안내하는 것이 자연스러울 수 있습니다

### 3. 에러 메세지 가이드 개선
- **현재 네트워크 오류를 제외한 문구들이 모호합니다.**
  -  예) "기록 저장에 실패했어요. 다시 시도해주세요" -> 사용자가 왜 실패했는지 알 수 없음. 원인에 대한 간략한 설명 필요.
  
### 4. 2회 초과 요청 다이얼로그 분기 불필요
- 1회 실패든 2회 초과든, 근본적인 해결책은 "네트워크/서버 상태 확인 후 재시도"로 동일합니다
- 별도 UI로 관리하면 문구, 디자인, 로직 분기 등 유지보수 복잡성만 증가하고, "2회 초과"를 안내하는 것은 UX적으로 추가 가치가 적다고 생각합니다

## 📌 For 지훈
- 현재 에러 관련 토스트로 처리한 부분은 굳이 제거하지 않았습니다. 기능 QA이후 결정이 되면 그때 다듬어요!
-  401 세션 만료까지는 제가 처리를 못했습니다... 이것 또한 QA 이후로 다듬겠습니다😢 
- 네트워크 없는 환경에서 Splash 진입 시 바로 로그인 화면으로 이동하는 이슈 있습니다. Splash에서 재시도 다이얼로그를 띄우던지 해야할 것 같네요
- 로그인,로그아웃,약관동의,회원탈퇴 -> 모두 다이얼로그로 일괄 처리해야하나 일단 보류하겠습니다
- 특히 로그인의 경우 카카오톡로그인, Reed회원가입/로그인 으로 구분되어 있어 이 부분 에러 처리도 어떻게 해야할지 고민이 필요합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 앱 전역에서 발생하는 오류를 안내하는 다이얼로그가 추가되어 사용자에게 명확한 피드백을 제공합니다.
  * 에러 UI 컴포넌트가 도입되어 네트워크 및 서버 오류 시 재시도 버튼과 함께 친숙한 메시지를 표시합니다.

* **버그 수정**
  * 에러 상태에 예외 객체를 포함하도록 개선하여, 보다 정확하고 상세한 오류 정보를 제공합니다.

* **UI/UX 개선**
  * 로딩, 성공, 에러 상태를 명확히 구분하여 사용자 경험을 향상시켰습니다.
  * 각 화면에서 오류 발생 시 일관된 에러 UI와 재시도 기능을 지원합니다.

* **문서 및 리소스**
  * 네트워크 및 서버 오류 관련 안내 문구가 추가되고, 사용하지 않는 문자열 리소스가 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->