### PR TITLE
fix: 감상문 가이드 선택 후 문장 맨 앞으로 커서 이동이 안되는 문제 해결

### DIFF
--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
@@ -1,8 +1,8 @@
 package com.ninecraft.booket.feature.record.register
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,10 +20,9 @@ import com.ninecraft.booket.core.designsystem.component.button.ReedButton
 import com.ninecraft.booket.core.designsystem.component.button.ReedButtonColorStyle
 import com.ninecraft.booket.core.designsystem.component.button.largeButtonStyle
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
-import com.ninecraft.booket.core.designsystem.theme.White
-import com.ninecraft.booket.core.ui.ReedScaffold
 import com.ninecraft.booket.core.ui.component.ReedBackTopAppBar
 import com.ninecraft.booket.core.ui.component.ReedDialog
+import com.ninecraft.booket.core.ui.component.ReedFullScreen
 import com.ninecraft.booket.feature.record.R
 import com.ninecraft.booket.feature.record.step.EmotionStep
 import com.ninecraft.booket.feature.record.step.ImpressionStep
@@ -34,7 +33,7 @@ import dagger.hilt.android.components.ActivityRetainedComponent
 
 @CircuitInject(RecordScreen::class, ActivityRetainedComponent::class)
 @Composable
-internal fun RecordRegister(
+internal fun RecordRegisterUi(
     state: RecordRegisterUiState,
     modifier: Modifier = Modifier,
 ) {
@@ -44,15 +43,8 @@ internal fun RecordRegister(
         state.eventSink(RecordRegisterUiEvent.OnBackButtonClick)
     }
 
-    ReedScaffold(
-        modifier = modifier.fillMaxSize(),
-        containerColor = White,
-    ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding),
-        ) {
+    ReedFullScreen(modifier = modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
             ReedBackTopAppBar(
                 onBackClick = {
                     state.eventSink(RecordRegisterUiEvent.OnBackButtonClick)
@@ -136,7 +128,7 @@ internal fun RecordRegister(
 @Composable
 private fun RecordRegisterPreview() {
     ReedTheme {
-        RecordRegister(
+        RecordRegisterUi(
             state = RecordRegisterUiState(
                 eventSink = {},
             ),

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -20,9 +21,9 @@ import com.ninecraft.booket.core.designsystem.component.button.ReedButton
 import com.ninecraft.booket.core.designsystem.component.button.ReedButtonColorStyle
 import com.ninecraft.booket.core.designsystem.component.button.largeButtonStyle
 import com.ninecraft.booket.core.designsystem.theme.ReedTheme
+import com.ninecraft.booket.core.designsystem.theme.White
 import com.ninecraft.booket.core.ui.component.ReedBackTopAppBar
 import com.ninecraft.booket.core.ui.component.ReedDialog
-import com.ninecraft.booket.core.ui.component.ReedFullScreen
 import com.ninecraft.booket.feature.record.R
 import com.ninecraft.booket.feature.record.step.EmotionStep
 import com.ninecraft.booket.feature.record.step.ImpressionStep
@@ -43,8 +44,15 @@ internal fun RecordRegisterUi(
         state.eventSink(RecordRegisterUiEvent.OnBackButtonClick)
     }
 
-    ReedFullScreen(modifier = modifier.fillMaxSize()) {
-        Column(modifier = Modifier.fillMaxSize()) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = White,
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
             ReedBackTopAppBar(
                 onBackClick = {
                     state.eventSink(RecordRegisterUiEvent.OnBackButtonClick)


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #127 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 기록 등록 화면에서 ReedScaffold -> ReedFullScreen으로 변경

## 💬 추가 설명 or 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 애뮬레이터(Android15)와 개인 단말(Android14)에서 확인했을 때 큰 이슈 없었는데, 크로스 체크 부탁드립니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기타**
  * UI 컴포넌트 이름이 변경되었습니다. (기존: RecordRegister → 변경: RecordRegisterUi)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->