### PR TITLE
refactor: emotionPairs chunked 연산 remember 적용

### DIFF
--- a/build-logic/src/main/kotlin/com/ninecraft/booket/convention/ApplicationConstants.kt
+++ b/build-logic/src/main/kotlin/com/ninecraft/booket/convention/ApplicationConstants.kt
@@ -7,7 +7,7 @@ internal object ApplicationConstants {
     const val TARGET_SDK = 35
     const val COMPILE_SDK = 35
     const val VERSION_CODE = 1
-    const val VERSION_NAME = "1.0"
+    const val VERSION_NAME = "1.0.0"
     const val JAVA_VERSION_INT = 17
     val javaVersion = JavaVersion.VERSION_17
 }

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/EmotionStep.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/EmotionStep.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -42,6 +43,8 @@ fun EmotionStep(
     state: RecordRegisterUiState,
     modifier: Modifier = Modifier,
 ) {
+    val emotionPairs = remember(state.emotionTags) { state.emotionTags.chunked(2) }
+
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -74,7 +77,6 @@ fun EmotionStep(
                 Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing10))
             }
 
-            val emotionPairs = state.emotionTags.chunked(2)
             items(emotionPairs) { pair ->
                 Row(
                     modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
--> 

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close https://github.com/YAPP-Github/Reed-Android/issues/132

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 리컴포지션마다 List chuncked 연산과 새 List 인스턴스 생성을 방지 

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **리팩터링**
  * 감정 태그 목록의 내부 처리 방식을 최적화하여 앱의 성능이 향상되었습니다. 사용자 경험이나 UI에는 변화가 없습니다.
* **기타**
  * 앱 버전명이 "1.0"에서 "1.0.0"으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->