### PR TITLE
[BOOK-260] feat: 스플래시 화면 네트워크 연결 에러 대응

### DIFF
--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/constants/ErrorDialogSpec.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/constants/ErrorDialogSpec.kt
@@ -2,6 +2,6 @@ package com.ninecraft.booket.core.common.constants
 
 data class ErrorDialogSpec(
     val message: String,
-    val buttonLabel: String,
+    val buttonLabelResId: Int,
     val action: () -> Unit,
 )

--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/utils/HandleException.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/utils/HandleException.kt
@@ -1,5 +1,7 @@
 package com.ninecraft.booket.core.common.utils
 
+import androidx.annotation.StringRes
+import com.ninecraft.booket.core.common.R
 import com.ninecraft.booket.core.common.constants.ErrorDialogSpec
 import com.ninecraft.booket.core.common.constants.ErrorScope
 import com.ninecraft.booket.core.common.event.ErrorEvent
@@ -46,11 +48,13 @@ fun handleException(
 fun postErrorDialog(
     errorScope: ErrorScope,
     exception: Throwable,
+    @StringRes buttonLabelResId: Int = R.string.confirm,
     action: () -> Unit = {},
 ) {
     val spec = buildDialog(
         scope = errorScope,
         exception = exception,
+        buttonLabelResId = buttonLabelResId,
         action = action,
     )
 
@@ -60,6 +64,7 @@ fun postErrorDialog(
 private fun buildDialog(
     scope: ErrorScope,
     exception: Throwable,
+    @StringRes buttonLabelResId: Int,
     action: () -> Unit,
 ): ErrorDialogSpec {
     val message = when {
@@ -92,7 +97,7 @@ private fun buildDialog(
         }
     }
 
-    return ErrorDialogSpec(message = message, buttonLabel = "확인", action = action)
+    return ErrorDialogSpec(message = message, buttonLabelResId = buttonLabelResId, action = action)
 }
 
 @Suppress("TooGenericExceptionCaught")

--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="book_status_completed">독서 완료</string>
     <string name="record_sort_page_ascending">페이지순</string>
     <string name="record_sort_recent_register">최신 등록순</string>
+    <string name="confirm">확인</string>
 </resources>

--- a/core/model/src/main/kotlin/com/ninecraft/booket/core/model/BookUpsertModel.kt
+++ b/core/model/src/main/kotlin/com/ninecraft/booket/core/model/BookUpsertModel.kt
@@ -1,8 +1,5 @@
 package com.ninecraft.booket.core.model
 
-import androidx.compose.runtime.Stable
-
-@Stable
 data class BookUpsertModel(
     val userBookId: String,
     val userId: String,

--- a/core/model/src/main/kotlin/com/ninecraft/booket/core/model/ReadingRecordsModel.kt
+++ b/core/model/src/main/kotlin/com/ninecraft/booket/core/model/ReadingRecordsModel.kt
@@ -1,5 +1,7 @@
 package com.ninecraft.booket.core.model
 
+import androidx.compose.runtime.Stable
+
 data class ReadingRecordsModel(
     val lastPage: Boolean = true,
     val totalResults: Int = 0,
@@ -8,6 +10,7 @@ data class ReadingRecordsModel(
     val readingRecords: List<ReadingRecordModel> = emptyList(),
 )
 
+@Stable
 data class ReadingRecordModel(
     val id: String = "",
     val userBookId: String = "",

--- a/core/ui/src/main/kotlin/com/ninecraft/booket/core/ui/ReedScaffold.kt
+++ b/core/ui/src/main/kotlin/com/ninecraft/booket/core/ui/ReedScaffold.kt
@@ -22,13 +22,13 @@ fun ReedScaffold(
     content: @Composable (PaddingValues) -> Unit,
 ) {
     Scaffold(
+        modifier = modifier.keyboardHide(),
         topBar = topBar,
         bottomBar = bottomBar,
         snackbarHost = snackbarHost,
         floatingActionButton = floatingActionButton,
         containerColor = containerColor,
         contentWindowInsets = contentWindowInsets,
-        modifier = modifier.keyboardHide(),
     ) { innerPadding ->
         content(innerPadding)
     }

--- a/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/MainActivity.kt
+++ b/feature/main/src/main/kotlin/com/ninecraft/booket/feature/main/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.ninecraft.booket.core.common.constants.ErrorDialogSpec
 import com.ninecraft.booket.core.common.event.ErrorEvent
@@ -70,7 +71,8 @@ class MainActivity : ComponentActivity() {
                 dialogSpec.value?.let { spec ->
                     ReedDialog(
                         description = spec.message,
-                        confirmButtonText = spec.buttonLabel,
+                        confirmButtonText = stringResource(spec.buttonLabelResId),
+
                         onConfirmRequest = {
                             spec.action()
                             dialogSpec.value = null

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterUi.kt
@@ -56,7 +56,7 @@ internal fun RecordRegisterUi(
             )
             RecordProgressBar(
                 currentStep = state.currentStep,
-                modifier = modifier.padding(horizontal = ReedTheme.spacing.spacing5),
+                modifier = Modifier.padding(horizontal = ReedTheme.spacing.spacing5),
             )
             Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing10))
             when (state.currentStep) {

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchPresenter.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchPresenter.kt
@@ -158,7 +158,7 @@ class BookSearchPresenter @AssistedInject constructor(
                 }
 
                 is BookSearchUiEvent.OnSearchClick -> {
-                    val query = event.text.trim()
+                    val query = event.query.trim()
                     if (query.isNotEmpty()) {
                         searchBooks(query = query, startIndex = START_INDEX)
                     }

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUi.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUi.kt
@@ -93,8 +93,8 @@ internal fun SearchContent(
         ReedTextField(
             queryState = state.queryState,
             queryHintRes = designR.string.search_book_hint,
-            onSearch = { text ->
-                state.eventSink(BookSearchUiEvent.OnSearchClick(text))
+            onSearch = { query ->
+                state.eventSink(BookSearchUiEvent.OnSearchClick(query))
             },
             onClear = {
                 state.eventSink(BookSearchUiEvent.OnClearClick)

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUi.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUi.kt
@@ -99,7 +99,7 @@ internal fun SearchContent(
             onClear = {
                 state.eventSink(BookSearchUiEvent.OnClearClick)
             },
-            modifier = modifier.padding(horizontal = ReedTheme.spacing.spacing5),
+            modifier = Modifier.padding(horizontal = ReedTheme.spacing.spacing5),
             borderStroke = BorderStroke(width = 1.dp, color = ReedTheme.colors.borderBrand),
             searchIconTint = ReedTheme.colors.contentBrand,
         )

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUiState.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUiState.kt
@@ -48,7 +48,7 @@ sealed interface BookSearchUiEvent : CircuitUiEvent {
     data object OnBackClick : BookSearchUiEvent
     data class OnRecentSearchClick(val query: String) : BookSearchUiEvent
     data class OnRecentSearchRemoveClick(val query: String) : BookSearchUiEvent
-    data class OnSearchClick(val text: String) : BookSearchUiEvent
+    data class OnSearchClick(val query: String) : BookSearchUiEvent
     data object OnClearClick : BookSearchUiEvent
     data class OnBookClick(val isbn13: String) : BookSearchUiEvent
     data object OnLoadMore : BookSearchUiEvent

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/library/LibrarySearchUi.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/library/LibrarySearchUi.kt
@@ -75,8 +75,8 @@ internal fun LibrarySearchContent(
         ReedTextField(
             queryState = state.queryState,
             queryHintRes = R.string.library_search_hint,
-            onSearch = { text ->
-                state.eventSink(LibrarySearchUiEvent.OnSearchClick(text))
+            onSearch = { query ->
+                state.eventSink(LibrarySearchUiEvent.OnSearchClick(query))
             },
             onClear = {
                 state.eventSink(LibrarySearchUiEvent.OnClearClick)

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/library/LibrarySearchUi.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/library/LibrarySearchUi.kt
@@ -81,7 +81,7 @@ internal fun LibrarySearchContent(
             onClear = {
                 state.eventSink(LibrarySearchUiEvent.OnClearClick)
             },
-            modifier = modifier.padding(horizontal = ReedTheme.spacing.spacing5),
+            modifier = Modifier.padding(horizontal = ReedTheme.spacing.spacing5),
             backgroundColor = ReedTheme.colors.baseSecondary,
             borderStroke = null,
         )

--- a/feature/settings/src/main/assets/oss_licenses.json
+++ b/feature/settings/src/main/assets/oss_licenses.json
@@ -45,6 +45,56 @@
         "url": "https://github.com/coil-kt/coil"
     },
     {
+        "name": "Landscapist",
+        "license": "Apache License 2.0",
+        "url": "https://github.com/skydoves/landscapist"
+    },
+    {
+        "name": "Google Analytics",
+        "license": "Apache License 2.0",
+        "url": "https://firebase.google.com/docs/analytics"
+    },
+    {
+        "name": "Firebase Crashlytics",
+        "license": "Apache License 2.0",
+        "url": "https://firebase.google.com/docs/crashlytics"
+    },
+    {
+        "name": "ML Kit Text Recognition",
+        "license": "Apache License 2.0",
+        "url": "https://developers.google.com/ml-kit/vision/text-recognition"
+    },
+    {
+        "name": "Compose System UI Controller",
+        "license": "MIT License",
+        "url": "https://github.com/taehwandev/ComposeExtensions"
+    },
+    {
+        "name": "Compose Keyboard State",
+        "license": "MIT License",
+        "url": "https://github.com/taehwandev/ComposeExtensions"
+    },
+    {
+        "name": "Lottie Compose",
+        "license": "Apache License 2.0",
+        "url": "https://github.com/airbnb/lottie-android"
+    },
+    {
+        "name": "Kakao SDK",
+        "license": "Apache License 2.0",
+        "url": "https://developers.kakao.com/docs/latest/ko/android/getting-started"
+    },
+    {
+        "name": "Kotlinx Collections Immutable",
+        "license": "Apache License 2.0",
+        "url": "https://github.com/Kotlin/kotlinx.collections.immutable"
+    },
+    {
+        "name": "Compose Shadow",
+        "license": "MIT license",
+        "url": "https://github.com/adamglin0/compose-shadow"
+    },
+    {
         "name": "Detekt",
         "license": "Apache License 2.0",
         "url": "https://github.com/detekt/detekt"

--- a/feature/settings/src/main/assets/oss_licenses.json
+++ b/feature/settings/src/main/assets/oss_licenses.json
@@ -91,7 +91,7 @@
     },
     {
         "name": "Compose Shadow",
-        "license": "MIT license",
+        "license": "MIT License",
         "url": "https://github.com/adamglin0/compose-shadow"
     },
     {

--- a/feature/splash/src/main/kotlin/com/ninecraft/booket/splash/SplashPresenter.kt
+++ b/feature/splash/src/main/kotlin/com/ninecraft/booket/splash/SplashPresenter.kt
@@ -6,10 +6,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import com.ninecraft.booket.core.common.constants.ErrorScope
+import com.ninecraft.booket.core.common.utils.postErrorDialog
 import com.ninecraft.booket.core.data.api.repository.AuthRepository
 import com.ninecraft.booket.core.data.api.repository.UserRepository
 import com.ninecraft.booket.core.model.AutoLoginState
 import com.ninecraft.booket.core.model.OnboardingState
+import com.ninecraft.booket.core.ui.R
 import com.ninecraft.booket.feature.screens.HomeScreen
 import com.ninecraft.booket.feature.screens.LoginScreen
 import com.ninecraft.booket.feature.screens.OnboardingScreen
@@ -50,8 +53,13 @@ class SplashPresenter @AssistedInject constructor(
                             navigator.resetRoot(LoginScreen)
                         }
                     }
-                    .onFailure {
-                        navigator.resetRoot(LoginScreen)
+                    .onFailure { exception ->
+                        postErrorDialog(
+                            errorScope = ErrorScope.GLOBAL,
+                            exception = exception,
+                            buttonLabelResId = R.string.retry,
+                            action = { checkTermsAgreement() },
+                        )
                     }
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -123,7 +123,6 @@ landscapist-placeholder = { group = "com.github.skydoves", name = "landscapist-p
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
-kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 
 circuit-foundation = { group = "com.slack.circuit", name = "circuit-foundation", version.ref = "circuit" }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close https://github.com/YAPP-Github/Reed-Android/issues/142

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 스플래시 화면 진입시 네트워크 연결이 없는 경우, 이후 화면으로 이동하지 않고 네트워크 에러 다이얼로그를 노출 

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
<img src="https://github.com/user-attachments/assets/1da095e3-a4da-480e-a1b4-f5d6bc06b0a0" width="300" />

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 에러 관련해서 중앙 집중화해서 관리하는 방식 넘 잘 구현된 것 같습니다. 기존 프로젝트에도 적용해봐야겠슴다
- 현재 도서 등록, 기록 플로우에서 토스트랑 다이얼로그가 둘다 뜨는데 다이얼로그만 띄워도될듯합니다. 관련해서 PD분들과 논의 후 제거하면 될 것 같슴다
- 에러 케이스에 대한 다이얼로그 figma 시안중에 '다시 시도하기'라는 buttonLabel이 있는데 현재 앱에서 쓰는 워딩은 '다시 시도'라 둘중 하나로 결정 후 통일하면 좋을 것 같습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 오류 다이얼로그 버튼 텍스트가 문자열 리소스를 사용하도록 변경되어 지역화 가능해졌습니다.
  * 인증 실패 시 스플래시에서 오류 다이얼로그를 띄우고 재시도로 흐름을 재시도할 수 있습니다.

* **데이터/모델**
  * 독서 기록 모델에 페이징 메타데이터 및 상세 항목(페이지, 인용문, 후기, 감정 태그, 저자 등) 추가 및 @Stable 적용.
  * 일부 모델의 안정성 애노테이션 변경(@Stable 제거 포함).

* **Chores**
  * 문자열 리소스(confirm) 및 여러 OSS 라이선스 항목 추가, kotlinx-datetime 의존성 항목 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->