### PR TITLE
fix: 감상평 가이드 버튼이 키보드에 가려지는 문제 해결

### DIFF
--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
@@ -74,15 +74,8 @@ fun ImpressionStep(
 
     LaunchedEffect(keyboardState, isImpressionTextFieldFocused) {
         if (keyboardState && isImpressionTextFieldFocused) {
-            delay(100)
+            delay(150)
             bringIntoViewRequester.bringIntoView()
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        if (state.impressionState.text.isEmpty()) {
-            focusRequester.requestFocus()
-            keyboardController?.show()
         }
     }
 
@@ -97,7 +90,7 @@ fun ImpressionStep(
                 .fillMaxWidth()
                 .weight(1f)
                 .padding(horizontal = ReedTheme.spacing.spacing5)
-                .padding(bottom = 12.dp)
+                .padding(bottom = 16.dp)
                 .verticalScroll(scrollState),
         ) {
             Text(

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/step/ImpressionStep.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.input.ImeAction
@@ -66,7 +65,6 @@ fun ImpressionStep(
     val coroutineScope = rememberCoroutineScope()
     val impressionGuideBottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val focusRequester = remember { FocusRequester() }
-    val keyboardController = LocalSoftwareKeyboardController.current
     val scrollState = rememberScrollState()
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
     val keyboardState by rememberKeyboardVisible()


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #158 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 작성한 감상평 없을 때 키보드 자동으로 올라오는 부분 제거
- 간헐적으로 감상평 가이드 키보드에 가려지는 문제 해결 

## 🧪 테스트 내역
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 💬 추가 설명 or 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 이전에는 UX를 고려하여 감상평 가이드 진입 시 키보드가 바로 올라오게 구현했으나, 감상평가이드 버튼과 다음 버튼이 밀려올라오면서 상단의 title과 description이 잘리는 문제 발생 -> 사용자가 textField 터치 시 올라도록 변경했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 초기 진입 시 키보드가 자동으로 열리던 현상 제거
  - 빈 입력란 자동 포커스를 제거해 의도치 않은 스크롤/입력 방지
- Style
  - 입력 영역 하단 여백을 12dp에서 16dp로 확대해 가독성 개선
  - 키보드 표시 시 화면 스크롤 타이밍을 미세 조정하여 전환을 더욱 부드럽게 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->