### PR TITLE
fix: CD steps내에 versionName 추출 로직 변경

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -38,16 +38,16 @@ jobs:
             -   name: Generate google-services.json
                 run: echo '${{ secrets.GOOGLE_SERVICES }}' | base64 -d > ./app/google-services.json
 
-            -   name: Extract Version Name from ApplicationConstants.kt
+            -   name: Extract Version Name from libs.versions.toml
                 run: |
                     set -euo pipefail
-                    VERSION=$(grep "VERSION_NAME" build-logic/src/main/kotlin/com/ninecraft/booket/convention/ApplicationConstants.kt | sed -E 's/.*VERSION_NAME\s*=\s*"([^"]+)".*/\1/')
+                    VERSION=$(grep "versionName" gradle/libs.versions.toml | sed -E 's/.*versionName\s*=\s*"([^"]+)".*/\1/')
                     if [[ -z "$VERSION" ]]; then
-                      echo "Error: ApplicationConstants.kt에서 VERSION_NAME 값을 추출하지 못했습니다." >&2
+                      echo "Error: toml에서 versionName 값을 추출하지 못했습니다." >&2
                       exit 1
                     fi
                     echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
-                    echo "Version extracted from ApplicationConstants.kt: v${VERSION}"
+                    echo "Version extracted from toml: v${VERSION}"
                 id: extract_version
 
             -   name: Generate Firebase Release Note


### PR DESCRIPTION
build-logic ApplicationConstants -> libs.version.toml

<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
--> 

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close https://github.com/YAPP-Github/Reed-Android/issues/161

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 제가 강제 업데이트 구현을 위해 여러 모듈에서 versionName을 가져올 수 있도록 libs.version.toml 내로 version 정보 및 앱에서 사용하는 상수들을 옮겨두었습니다.
- 관련 변경사항에 의해 CD steps이 실패하여 CD steps 내에 versionName 추출 로직을 변경하였습니다.

## 🧪 테스트 내역 (선택)
- [ ] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [ ] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->


## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Android 지속적 배포 파이프라인에서 앱 버전을 중앙 설정에서 추출하도록 조정하여 관리 일관성을 높였습니다.
  - 성공/실패 로그 메시지를 명확화해 배포 과정에서의 가시성과 문제 진단 용이성을 개선했습니다.
  - 버전 검증 및 출력 형식은 유지되어 기존 연동에 영향이 없습니다.
  - 결과적으로 빌드·배포 신뢰성과 안정성이 향상되며, 최종 사용자 기능이나 UI 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->