### PR TITLE
fix: 감상평 입력시 0 페이지 입력 validation 추가

### DIFF
--- a/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/textfield/InputTransformation.kt
+++ b/core/designsystem/src/main/kotlin/com/ninecraft/booket/core/designsystem/component/textfield/InputTransformation.kt
@@ -10,7 +10,6 @@ val digitOnlyInputTransformation = { text: TextFieldBuffer ->
 
     val transformed = when {
         filtered.isEmpty() -> ""
-        filtered == "0" -> "0" // 0 하나만 허용
         filtered.startsWith("0") -> filtered.trimStart('0') // 선행 0 제거
         else -> filtered
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,12 @@
 [versions]
+## App Configuration
+minSdk = "28"
+targetSdk = "35"
+compileSdk = "35"
+versionName = "1.1.2"
+versionCode = "6"
+packageName = "com.ninecraft.booket"
+
 ## Android gradle plugin
 android-gradle-plugin = "8.9.3"
 
@@ -74,14 +82,6 @@ androidx-test-runner = "1.6.2"
 google-service = "4.4.3"
 firebase-bom = "34.1.0"
 firebase-crashlytics = "3.0.4"
-
-## App Configuration
-minSdk = "28"
-targetSdk = "35"
-compileSdk = "35"
-versionName = "1.1.1"
-versionCode = "5"
-packageName = "com.ninecraft.booket"
 
 [libraries]
 android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-gradle-plugin" }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close https://github.com/YAPP-Github/Reed-Android/issues/169

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 선행 0 입력되는 어떠한 경우는 입력에서 제거 
- 앱 버전 업데이트 (1.1.1 -> 1.1.2)

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 수량이나, 금액등이 아니라 책의 페이지인 관계로 선행 0 입력은 어느경우에나 지우는게 맞기에 제거되도록 했습니다
