### PR TITLE
feat: Guest Mode 약관동의 화면에서 앱 종료되는 문제 해결

### DIFF
--- a/app/src/main/kotlin/com/ninecraft/booket/di/CircuitModule.kt
+++ b/app/src/main/kotlin/com/ninecraft/booket/di/CircuitModule.kt
@@ -28,7 +28,7 @@ abstract class CircuitModule {
         ): Circuit = Circuit.Builder()
             .addPresenterFactories(presenterFactories)
             .addUiFactories(uiFactories)
-            // .setAnimatedNavDecoratorFactory(CrossFadeNavDecoratorFactory())
+            .setAnimatedNavDecoratorFactory(CrossFadeNavDecoratorFactory())
             .build()
     }
 }

--- a/app/src/main/kotlin/com/ninecraft/booket/di/CrossFadeNavDecorator.kt
+++ b/app/src/main/kotlin/com/ninecraft/booket/di/CrossFadeNavDecorator.kt
@@ -15,7 +15,7 @@ import com.slack.circuit.foundation.animation.AnimatedNavDecorator
 import com.slack.circuit.foundation.animation.AnimatedNavEvent
 import com.slack.circuit.foundation.animation.AnimatedNavState
 
-data class CrossFadeNavDecoratorFactory(val durationMillis: Int = 300) :
+data class CrossFadeNavDecoratorFactory(val durationMillis: Int = 500) :
     AnimatedNavDecorator.Factory {
     override fun <T : NavArgument> create(): AnimatedNavDecorator<T, *> =
         CrossFadeNavDecorator(durationMillis)

--- a/app/src/main/kotlin/com/ninecraft/booket/di/CrossFadeNavDecorator.kt
+++ b/app/src/main/kotlin/com/ninecraft/booket/di/CrossFadeNavDecorator.kt
@@ -6,6 +6,9 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import com.ninecraft.booket.feature.screens.LoginScreen
+import com.ninecraft.booket.feature.screens.SplashScreen
+import com.ninecraft.booket.feature.screens.TermsAgreementScreen
 import com.slack.circuit.backstack.NavArgument
 import com.slack.circuit.foundation.NavigatorDefaults
 import com.slack.circuit.foundation.animation.AnimatedNavDecorator
@@ -24,6 +27,34 @@ class CrossFadeNavDecorator<T : NavArgument>(private val durationMillis: Int) :
     override fun AnimatedContentTransitionScope<AnimatedNavState>.transitionSpec(
         animatedNavEvent: AnimatedNavEvent,
     ): ContentTransform {
-        return fadeIn(tween(durationMillis)) togetherWith fadeOut(tween(durationMillis))
+        val shouldUseFade = shouldUseFadeAnimation(initialState, targetState)
+
+        return if (shouldUseFade) {
+            fadeIn(tween(durationMillis)) togetherWith fadeOut(tween(durationMillis))
+        } else {
+            // Circuit 기본 애니메이션 사용
+            with(NavigatorDefaults.DefaultDecorator<T>()) {
+                transitionSpec(animatedNavEvent)
+            }
+        }
+    }
+
+    private fun shouldUseFadeAnimation(
+        initialState: AnimatedNavState,
+        targetState: AnimatedNavState,
+    ): Boolean {
+        val fadeScreens = setOf(
+            SplashScreen::class,
+            LoginScreen::class,
+            TermsAgreementScreen::class,
+        )
+
+        val initialScreenClass = initialState.top.screen::class
+        val targetScreenClass = targetState.top.screen::class
+
+        // 앱 시작시 SplashScreen이 첫 화면인 경우 처리
+        val isAppLaunchToSplash = targetScreenClass == SplashScreen::class
+
+        return isAppLaunchToSplash || initialScreenClass in fadeScreens || targetScreenClass in fadeScreens
     }
 }

--- a/feature/login/src/main/kotlin/com/ninecraft/booket/feature/login/LoginPresenter.kt
+++ b/feature/login/src/main/kotlin/com/ninecraft/booket/feature/login/LoginPresenter.kt
@@ -53,7 +53,11 @@ class LoginPresenter @AssistedInject constructor(
                                 navigator.popUntil { it == screen.returnToScreen }
                             }
                         } else {
-                            navigator.resetRoot(TermsAgreementScreen(screen.returnToScreen))
+                            if (screen.returnToScreen == null) {
+                                navigator.resetRoot(TermsAgreementScreen())
+                            } else {
+                                navigator.goTo(TermsAgreementScreen(screen.returnToScreen))
+                            }
                         }
                     }.onFailure { exception ->
                         exception.message?.let { Logger.e(it) }

--- a/feature/splash/src/main/kotlin/com/ninecraft/booket/splash/SplashUi.kt
+++ b/feature/splash/src/main/kotlin/com/ninecraft/booket/splash/SplashUi.kt
@@ -1,6 +1,5 @@
 package com.ninecraft.booket.splash
 
-import android.R.attr.description
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ minSdk = "28"
 targetSdk = "35"
 compileSdk = "35"
 versionName = "1.2.0"
-versionCode = "7"
+versionCode = "8"
 packageName = "com.ninecraft.booket"
 
 ## Android gradle plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ okhttp = "5.1.0"
 retrofit = "3.0.0"
 
 ## Circuit
-circuit = "0.29.1"
+circuit = "0.30.0"
 
 ## Logging
 logger = "2.2.0"


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close https://github.com/YAPP-Github/Reed-Android/issues/178

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- Guest Mode로 약관동의 화면 진입시 백스택을 날리고 진입하여 약관동의 이후 모든 백스택이 빠져나가서 앱이 종료되는 문제를 해결
- splash, login, termsAgreem 화면 전환시 fadeIn-fadeOut animation 적용 

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
Before

https://github.com/user-attachments/assets/05250da2-073f-4d35-87f5-888bd3da7053

After

https://github.com/user-attachments/assets/e313973a-c397-460f-828b-8126a7f18d8c

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 테스트 마지막으로 해보고 업데이트 하면 좋을것같습니다~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능/개선
  * 화면 전환 애니메이션(크로스페이드) 활성화 및 개선: 앱 시작→스플래시, 스플래시/로그인/이용약관 간 전환에 부드러운 페이드 적용. 기본 전환은 유지.
  * 로그인 후 이용약관 동의 흐름 개선: 돌아갈 화면이 있으면 스택을 유지해 이동, 없으면 초기화 후 이동.
* 기타(Chores)
  * 앱 버전 코드 8로 상향.
  * Circuit 라이브러리 0.30.0으로 업데이트.
  * 불필요한 임포트 정리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->